### PR TITLE
Start Platform Core tenancy foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,20 @@ on:
 jobs:
   qa:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: batios
+          POSTGRES_PASSWORD: batios
+          POSTGRES_DB: batios_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U batios -d batios_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -22,4 +36,6 @@ jobs:
       - run: pnpm -r lint
       - run: pnpm -r typecheck
       - run: pnpm -r test
+        env:
+          BATIOS_TEST_DATABASE_URL: postgres://batios:batios@localhost:5432/batios_test
       - run: node compliance-mapper-stub.mjs

--- a/packages/platform-core/package.json
+++ b/packages/platform-core/package.json
@@ -15,6 +15,10 @@
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
-    "kysely": "^0.27.5"
+    "kysely": "^0.27.5",
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.20.0"
   }
 }

--- a/packages/platform-core/src/index.ts
+++ b/packages/platform-core/src/index.ts
@@ -1,3 +1,4 @@
 export const platformCoreBoundary = 'platform-core';
 
+export * from './migrations/index.js';
 export * as tenancyFoundationsMigration from './migrations/0001-tenancy-foundations.js';

--- a/packages/platform-core/src/migrations/0001-tenancy-foundations.ts
+++ b/packages/platform-core/src/migrations/0001-tenancy-foundations.ts
@@ -155,12 +155,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn('organisation_id', 'uuid', (c) =>
       c.notNull().references('organisations.organisation_id').onDelete('restrict'),
     )
-    .addColumn('tenant_hash', 'text', (c) =>
-      c
-        .notNull()
-        .generatedAlwaysAs(
-          sql`encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')`,
-        ),
+    .addColumn(
+      'tenant_hash',
+      sql`text GENERATED ALWAYS AS (encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')) STORED`,
+      (c) => c.notNull(),
     )
     .addColumn('display_name', 'text', (c) => c.notNull())
     .addColumn('contract_reference', 'text', (c) => c.notNull())
@@ -221,12 +219,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn('organisation_id', 'uuid', (c) =>
       c.notNull().references('organisations.organisation_id').onDelete('restrict'),
     )
-    .addColumn('tenant_hash', 'text', (c) =>
-      c
-        .notNull()
-        .generatedAlwaysAs(
-          sql`encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')`,
-        ),
+    .addColumn(
+      'tenant_hash',
+      sql`text GENERATED ALWAYS AS (encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')) STORED`,
+      (c) => c.notNull(),
     )
     .addColumn('party_role', 'text', (c) => c.notNull())
     .addColumn('custody_level', 'text', (c) => c.notNull().defaultTo('read'))
@@ -338,12 +334,10 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn('user_id', 'uuid', (c) => c.notNull())
     .addColumn('project_id', 'uuid', (c) => c.notNull())
     .addColumn('organisation_id', 'uuid', (c) => c.notNull())
-    .addColumn('tenant_hash', 'text', (c) =>
-      c
-        .notNull()
-        .generatedAlwaysAs(
-          sql`encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')`,
-        ),
+    .addColumn(
+      'tenant_hash',
+      sql`text GENERATED ALWAYS AS (encode(digest(organisation_id::text || ':' || project_id::text, 'sha256'), 'hex')) STORED`,
+      (c) => c.notNull(),
     )
     .addColumn('role', 'text', (c) => c.notNull())
     .addColumn('granted_at', 'timestamptz', (c) => c.notNull().defaultTo(sql`now()`))

--- a/packages/platform-core/src/migrations/0001-tenancy-foundations.ts
+++ b/packages/platform-core/src/migrations/0001-tenancy-foundations.ts
@@ -442,7 +442,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   `.execute(db);
 }
 
-export async function down(_db: Kysely<unknown>): Promise<void> {
+export async function down(_db?: Kysely<unknown>): Promise<void> {
   // No down migrations per platform architecture. Roll back by restoring a prior
   // snapshot and re-running migrations forward.
   throw new Error(

--- a/packages/platform-core/src/migrations/index.test.ts
+++ b/packages/platform-core/src/migrations/index.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import * as tenancyFoundations from './0001-tenancy-foundations.js';
+import {
+  PlatformMigrationProvider,
+  TENANCY_FOUNDATIONS_MIGRATION_ID,
+  platformMigrationIds,
+} from './index.js';
+
+describe('platform migration registry', () => {
+  it('registers tenancy foundations as the first platform migration', async () => {
+    const provider = new PlatformMigrationProvider();
+    const migrations = await provider.getMigrations();
+
+    expect(platformMigrationIds).toEqual([TENANCY_FOUNDATIONS_MIGRATION_ID]);
+    expect(migrations[TENANCY_FOUNDATIONS_MIGRATION_ID]).toBe(tenancyFoundations);
+    expect(migrations[TENANCY_FOUNDATIONS_MIGRATION_ID].up).toBeTypeOf('function');
+    expect(migrations[TENANCY_FOUNDATIONS_MIGRATION_ID].down).toBeTypeOf('function');
+  });
+
+  it('keeps platform migrations forward-only', async () => {
+    await expect(tenancyFoundations.down()).rejects.toThrow('down migrations are not supported');
+  });
+
+  it('keeps tenant-scoped tables protected by RLS and policies', async () => {
+    const source = await readFile(
+      new URL('./0001-tenancy-foundations.ts', import.meta.url),
+      'utf8',
+    );
+
+    for (const table of [
+      'organisations',
+      'users',
+      'projects',
+      'project_parties',
+      'project_roles',
+    ]) {
+      expect(source).toContain(`ALTER TABLE ${table} ENABLE ROW LEVEL SECURITY`);
+      expect(source).toContain(`ALTER TABLE ${table} FORCE ROW LEVEL SECURITY`);
+    }
+
+    for (const policy of [
+      'organisations_self_read',
+      'users_owner_read',
+      'projects_owner_read',
+      'projects_joint_custody_read',
+      'project_parties_participant_read',
+      'project_roles_owner_read',
+    ]) {
+      expect(source).toContain(`CREATE POLICY ${policy}`);
+    }
+  });
+});

--- a/packages/platform-core/src/migrations/index.ts
+++ b/packages/platform-core/src/migrations/index.ts
@@ -1,0 +1,35 @@
+import { type Kysely, type Migration, Migrator, type MigrationProvider } from 'kysely';
+
+import * as tenancyFoundations from './0001-tenancy-foundations.js';
+
+export const TENANCY_FOUNDATIONS_MIGRATION_ID = '0001-tenancy-foundations';
+
+export const platformMigrationIds = [TENANCY_FOUNDATIONS_MIGRATION_ID] as const;
+
+export type PlatformMigrationId = (typeof platformMigrationIds)[number];
+
+export class PlatformMigrationProvider implements MigrationProvider {
+  async getMigrations(): Promise<Record<PlatformMigrationId, Migration>> {
+    return {
+      [TENANCY_FOUNDATIONS_MIGRATION_ID]: tenancyFoundations,
+    };
+  }
+}
+
+export function createPlatformMigrator(db: Kysely<unknown>): Migrator {
+  return new Migrator({
+    db,
+    provider: new PlatformMigrationProvider(),
+    migrationTableName: 'platform_migrations',
+    migrationLockTableName: 'platform_migration_lock',
+  });
+}
+
+export async function migratePlatformToLatest(db: Kysely<unknown>): Promise<void> {
+  const migrator = createPlatformMigrator(db);
+  const { error } = await migrator.migrateToLatest();
+
+  if (error) {
+    throw error;
+  }
+}

--- a/packages/platform-core/test/integration/tenancy-foundations.integration.test.ts
+++ b/packages/platform-core/test/integration/tenancy-foundations.integration.test.ts
@@ -46,20 +46,41 @@ const databaseUrl = process.env.BATIOS_TEST_DATABASE_URL;
 const describeWithDatabase = databaseUrl ? describe : describe.skip;
 
 describeWithDatabase('tenancy foundations migration', () => {
-  let pool: Pool;
+  let adminPool: Pool;
+  let adminDb: Kysely<TenancyTestDatabase>;
+  let appPool: Pool;
   let db: Kysely<TenancyTestDatabase>;
 
   beforeAll(async () => {
-    pool = new Pool({ connectionString: databaseUrl });
-    db = new Kysely<TenancyTestDatabase>({
-      dialect: new PostgresDialect({ pool }),
+    adminPool = new Pool({ connectionString: databaseUrl });
+    adminDb = new Kysely<TenancyTestDatabase>({
+      dialect: new PostgresDialect({ pool: adminPool }),
     });
 
-    await migratePlatformToLatest(db);
+    await migratePlatformToLatest(adminDb);
+    await sql`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'batios_app') THEN
+          CREATE ROLE batios_app LOGIN PASSWORD 'batios_app';
+        END IF;
+      END
+      $$;
+    `.execute(adminDb);
+    await sql`GRANT USAGE ON SCHEMA public TO batios_app`.execute(adminDb);
+    await sql`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO batios_app`.execute(
+      adminDb,
+    );
+
+    appPool = new Pool({ connectionString: createAppDatabaseUrl(databaseUrl) });
+    db = new Kysely<TenancyTestDatabase>({
+      dialect: new PostgresDialect({ pool: appPool }),
+    });
   });
 
   afterAll(async () => {
     await db.destroy();
+    await adminDb.destroy();
   });
 
   it('enforces owner-only organisation reads and joint-custody project reads', async () => {
@@ -149,3 +170,14 @@ describeWithDatabase('tenancy foundations migration', () => {
     await expect(db.selectFrom('projects').selectAll().execute()).resolves.toHaveLength(0);
   });
 });
+
+function createAppDatabaseUrl(connectionString: string | undefined): string {
+  if (!connectionString) {
+    throw new Error('BATIOS_TEST_DATABASE_URL is required');
+  }
+
+  const url = new URL(connectionString);
+  url.username = 'batios_app';
+  url.password = 'batios_app';
+  return url.toString();
+}

--- a/packages/platform-core/test/integration/tenancy-foundations.integration.test.ts
+++ b/packages/platform-core/test/integration/tenancy-foundations.integration.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto';
+
+import { Kysely, PostgresDialect, sql } from 'kysely';
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { migratePlatformToLatest } from '../../src/migrations/index.js';
+
+interface TenancyTestDatabase {
+  organisations: {
+    organisation_id: string;
+    display_name: string;
+    slug: string;
+    kind: string;
+    country_code: string;
+    status: string;
+    created_at: Date;
+    last_modified_at: Date;
+  };
+  projects: {
+    project_id: string;
+    organisation_id: string;
+    tenant_hash: string;
+    display_name: string;
+    contract_reference: string;
+    status: string;
+    created_at: Date;
+    last_modified_at: Date;
+  };
+  project_parties: {
+    project_party_id: string;
+    project_id: string;
+    project_owner_organisation_id: string;
+    organisation_id: string;
+    tenant_hash: string;
+    party_role: string;
+    custody_level: string;
+    granted_at: Date;
+    granted_by_user_id: string | null;
+    revoked_at: Date | null;
+    revoked_by_user_id: string | null;
+  };
+}
+
+const databaseUrl = process.env.BATIOS_TEST_DATABASE_URL;
+const describeWithDatabase = databaseUrl ? describe : describe.skip;
+
+describeWithDatabase('tenancy foundations migration', () => {
+  let pool: Pool;
+  let db: Kysely<TenancyTestDatabase>;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: databaseUrl });
+    db = new Kysely<TenancyTestDatabase>({
+      dialect: new PostgresDialect({ pool }),
+    });
+
+    await migratePlatformToLatest(db);
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it('enforces owner-only organisation reads and joint-custody project reads', async () => {
+    const ownerOrganisationId = randomUUID();
+    const custodyOrganisationId = randomUUID();
+    const outsiderOrganisationId = randomUUID();
+    const projectId = randomUUID();
+
+    await sql`SELECT set_config('batios.organisation_id', ${ownerOrganisationId}, false)`.execute(
+      db,
+    );
+    await db
+      .insertInto('organisations')
+      .values({
+        organisation_id: ownerOrganisationId,
+        display_name: 'Owner',
+        slug: `owner-${projectId}`,
+        kind: 'Contractor',
+      })
+      .execute();
+
+    await sql`SELECT set_config('batios.organisation_id', ${custodyOrganisationId}, false)`.execute(
+      db,
+    );
+    await db
+      .insertInto('organisations')
+      .values({
+        organisation_id: custodyOrganisationId,
+        display_name: 'Custody',
+        slug: `custody-${projectId}`,
+        kind: 'PM',
+      })
+      .execute();
+
+    await sql`SELECT set_config('batios.organisation_id', ${outsiderOrganisationId}, false)`.execute(
+      db,
+    );
+    await db
+      .insertInto('organisations')
+      .values({
+        organisation_id: outsiderOrganisationId,
+        display_name: 'Outsider',
+        slug: `outsider-${projectId}`,
+        kind: 'External',
+      })
+      .execute();
+
+    await sql`SELECT set_config('batios.organisation_id', ${ownerOrganisationId}, false)`.execute(
+      db,
+    );
+    await db
+      .insertInto('projects')
+      .values({
+        project_id: projectId,
+        organisation_id: ownerOrganisationId,
+        display_name: 'RLS test project',
+        contract_reference: `RLS-${projectId}`,
+      })
+      .execute();
+
+    await db
+      .insertInto('project_parties')
+      .values({
+        project_id: projectId,
+        project_owner_organisation_id: ownerOrganisationId,
+        organisation_id: custodyOrganisationId,
+        party_role: 'PM',
+      })
+      .execute();
+
+    await sql`SELECT set_config('batios.organisation_id', ${ownerOrganisationId}, false)`.execute(
+      db,
+    );
+    await expect(db.selectFrom('organisations').selectAll().execute()).resolves.toHaveLength(1);
+    await expect(db.selectFrom('projects').selectAll().execute()).resolves.toHaveLength(1);
+
+    await sql`SELECT set_config('batios.organisation_id', ${custodyOrganisationId}, false)`.execute(
+      db,
+    );
+    await expect(db.selectFrom('organisations').selectAll().execute()).resolves.toHaveLength(1);
+    await expect(db.selectFrom('projects').selectAll().execute()).resolves.toHaveLength(1);
+
+    await sql`SELECT set_config('batios.organisation_id', ${outsiderOrganisationId}, false)`.execute(
+      db,
+    );
+    await expect(db.selectFrom('organisations').selectAll().execute()).resolves.toHaveLength(1);
+    await expect(db.selectFrom('projects').selectAll().execute()).resolves.toHaveLength(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,13 @@ importers:
       kysely:
         specifier: ^0.27.5
         version: 0.27.6
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
 
   packages/qa-harness: {}
 
@@ -1227,6 +1234,12 @@ packages:
     resolution:
       {
         integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==,
+      }
+
+  '@types/pg@8.20.0':
+    resolution:
+      {
+        integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==,
       }
 
   '@types/react-dom@19.2.3':
@@ -2659,6 +2672,64 @@ packages:
       }
     engines: { node: '>= 14.16' }
 
+  pg-cloudflare@1.3.0:
+    resolution:
+      {
+        integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==,
+      }
+
+  pg-connection-string@2.12.0:
+    resolution:
+      {
+        integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==,
+      }
+
+  pg-int8@1.0.1:
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+      }
+    engines: { node: '>=4.0.0' }
+
+  pg-pool@3.13.0:
+    resolution:
+      {
+        integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==,
+      }
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution:
+      {
+        integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==,
+      }
+
+  pg-types@2.2.0:
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+      }
+    engines: { node: '>=4' }
+
+  pg@8.20.0:
+    resolution:
+      {
+        integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==,
+      }
+    engines: { node: '>= 16.0.0' }
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -2699,6 +2770,34 @@ packages:
         integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==,
       }
     engines: { node: ^10 || ^12 || >=14 }
+
+  postgres-array@2.0.0:
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+      }
+    engines: { node: '>=4' }
+
+  postgres-bytea@1.0.1:
+    resolution:
+      {
+        integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  postgres-date@1.0.7:
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  postgres-interval@1.2.0:
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   prelude-ls@1.2.1:
     resolution:
@@ -2923,6 +3022,13 @@ packages:
         integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
       }
     engines: { node: '>=0.10.0' }
+
+  split2@4.2.0:
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: '>= 10.x' }
 
   stackback@0.0.2:
     resolution:
@@ -3266,6 +3372,13 @@ packages:
         integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
       }
     engines: { node: '>=0.10.0' }
+
+  xtend@4.0.2:
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: '>=0.4' }
 
   yocto-queue@0.1.0:
     resolution:
@@ -3720,6 +3833,12 @@ snapshots:
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 20.19.39
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -4760,6 +4879,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4779,6 +4933,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -4981,6 +5145,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -5233,5 +5399,7 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
## Summary
- Add a PlatformMigrationProvider and createPlatformMigrator/migratePlatformToLatest helpers for platform-core
- Register the tenancy foundations migration as the first platform migration
- Add unit coverage for migration registration, forward-only migrations, and RLS policy presence
- Add an opt-in Postgres integration test gated by BATIOS_TEST_DATABASE_URL

Refs #1

## Verification
- corepack pnpm --filter @batios/platform-core typecheck
- corepack pnpm --filter @batios/platform-core test
- corepack pnpm --filter @batios/platform-core lint
- corepack pnpm run format:check
- corepack pnpm run lint
- corepack pnpm run typecheck
- corepack pnpm run test
- corepack pnpm run compliance:scan
- corepack pnpm run build