### PR TITLE
Add events-core artifact event append API

### DIFF
--- a/compliance-mapper-stub.mjs
+++ b/compliance-mapper-stub.mjs
@@ -59,7 +59,7 @@ const RULES = [
 function walk(dir, callback) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
-    const rel = relative(REPO_ROOT, full);
+    const rel = relative(REPO_ROOT, full).replaceAll('\\', '/');
     if (
       entry === 'node_modules' ||
       entry === 'dist' ||

--- a/packages/events-core/package.json
+++ b/packages/events-core/package.json
@@ -13,5 +13,8 @@
     "test": "vitest run --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests --dir test/integration",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "kysely": "^0.27.5"
   }
 }

--- a/packages/events-core/src/artifact-events.test.ts
+++ b/packages/events-core/src/artifact-events.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { toArtifactEventInsert, type ArtifactEventInput } from './artifact-events.js';
+
+const baseInput: ArtifactEventInput = {
+  artifactId: '11111111-1111-4111-8111-111111111111',
+  projectId: '22222222-2222-4222-8222-222222222222',
+  organisationId: '33333333-3333-4333-8333-333333333333',
+  eventType: 'artifact.created',
+  actorUserId: '44444444-4444-4444-8444-444444444444',
+  idempotencyKey: 'artifact:11111111-1111-4111-8111-111111111111:create',
+  payload: {
+    artifactKind: 'invoice',
+    amount: 125000,
+    tags: ['contract', 'payment'],
+    verified: false,
+  },
+};
+
+describe('artifact event append input', () => {
+  it('maps typed domain input to the append-only table shape', () => {
+    const occurredAt = new Date('2026-04-27T10:00:00.000Z');
+    const insert = toArtifactEventInsert({
+      ...baseInput,
+      eventId: '55555555-5555-4555-8555-555555555555',
+      eventVersion: 2,
+      occurredAt,
+      causationId: '66666666-6666-4666-8666-666666666666',
+      correlationId: '77777777-7777-4777-8777-777777777777',
+    });
+
+    expect(insert).toEqual({
+      event_id: '55555555-5555-4555-8555-555555555555',
+      artifact_id: baseInput.artifactId,
+      project_id: baseInput.projectId,
+      organisation_id: baseInput.organisationId,
+      event_type: 'artifact.created',
+      event_version: 2,
+      occurred_at: occurredAt,
+      actor_user_id: baseInput.actorUserId,
+      idempotency_key: baseInput.idempotencyKey,
+      payload: baseInput.payload,
+      causation_id: '66666666-6666-4666-8666-666666666666',
+      correlation_id: '77777777-7777-4777-8777-777777777777',
+    });
+  });
+
+  it('defaults event version and nullable linkage fields for append callers', () => {
+    const insert = toArtifactEventInsert(baseInput);
+
+    expect(insert.event_version).toBe(1);
+    expect(insert.occurred_at).toBeInstanceOf(Date);
+    expect(insert.causation_id).toBeNull();
+    expect(insert.correlation_id).toBeNull();
+    expect(insert).not.toHaveProperty('event_id');
+  });
+});

--- a/packages/events-core/src/artifact-events.ts
+++ b/packages/events-core/src/artifact-events.ts
@@ -1,0 +1,98 @@
+import { type Generated, type Insertable, type Kysely, type Selectable } from 'kysely';
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type ArtifactEventPayload = Readonly<Record<string, JsonValue>>;
+
+export type ArtifactEventType =
+  | 'artifact.created'
+  | 'artifact.updated'
+  | 'artifact.attached'
+  | 'artifact.reviewed'
+  | 'artifact.approved'
+  | 'artifact.rejected'
+  | 'artifact.superseded';
+
+export interface ArtifactEventsTable {
+  event_id: Generated<string>;
+  artifact_id: string;
+  project_id: string;
+  organisation_id: string;
+  event_type: ArtifactEventType;
+  event_version: Generated<number>;
+  occurred_at: Generated<Date>;
+  actor_user_id: string;
+  idempotency_key: string;
+  payload: ArtifactEventPayload;
+  causation_id: string | null;
+  correlation_id: string | null;
+}
+
+export interface ArtifactEventsDatabase {
+  artifact_events: ArtifactEventsTable;
+}
+
+export interface ArtifactEventInput {
+  eventId?: string;
+  artifactId: string;
+  projectId: string;
+  organisationId: string;
+  eventType: ArtifactEventType;
+  eventVersion?: number;
+  occurredAt?: Date;
+  actorUserId: string;
+  idempotencyKey: string;
+  payload: ArtifactEventPayload;
+  causationId?: string | null;
+  correlationId?: string | null;
+}
+
+export type ArtifactEventInsert = Insertable<ArtifactEventsTable>;
+export type ArtifactEventRow = Selectable<ArtifactEventsTable>;
+
+export function toArtifactEventInsert(input: ArtifactEventInput): ArtifactEventInsert {
+  const insert: ArtifactEventInsert = {
+    artifact_id: input.artifactId,
+    project_id: input.projectId,
+    organisation_id: input.organisationId,
+    event_type: input.eventType,
+    event_version: input.eventVersion ?? 1,
+    occurred_at: input.occurredAt ?? new Date(),
+    actor_user_id: input.actorUserId,
+    idempotency_key: input.idempotencyKey,
+    payload: input.payload,
+    causation_id: input.causationId ?? null,
+    correlation_id: input.correlationId ?? null,
+  };
+
+  if (input.eventId !== undefined) {
+    insert.event_id = input.eventId;
+  }
+
+  return insert;
+}
+
+export async function appendArtifactEvent(
+  db: Kysely<ArtifactEventsDatabase>,
+  input: ArtifactEventInput,
+): Promise<ArtifactEventRow> {
+  return await db
+    .insertInto('artifact_events')
+    .values(toArtifactEventInsert(input))
+    .returningAll()
+    .executeTakeFirstOrThrow();
+}
+
+export function createArtifactEventsRepository(db: Kysely<ArtifactEventsDatabase>): {
+  append: (input: ArtifactEventInput) => Promise<ArtifactEventRow>;
+} {
+  return {
+    append: (input) => appendArtifactEvent(db, input),
+  };
+}

--- a/packages/events-core/src/index.ts
+++ b/packages/events-core/src/index.ts
@@ -1,1 +1,5 @@
 export const eventsCoreBoundary = 'events-core';
+
+export * from './artifact-events.js';
+export * from './migrations/index.js';
+export * as artifactEventsMigration from './migrations/0001-artifact-events.js';

--- a/packages/events-core/src/migrations/0001-artifact-events.ts
+++ b/packages/events-core/src/migrations/0001-artifact-events.ts
@@ -1,0 +1,121 @@
+/**
+ * Migration 0001: artifact events
+ *
+ * Artifact events are append-only evidence records. Writes go through
+ * packages/events-core so callers get typed payloads, idempotency, and a single
+ * policy boundary for compliance scanning.
+ */
+
+import { type Kysely, sql } from 'kysely';
+
+const currentOrganisationId = sql`nullif(current_setting('batios.organisation_id', true), '')::uuid`;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`.execute(db);
+
+  await db.schema
+    .createTable('artifact_events')
+    .addColumn('event_id', 'uuid', (c) => c.primaryKey().defaultTo(sql`gen_random_uuid()`))
+    .addColumn('artifact_id', 'uuid', (c) => c.notNull())
+    .addColumn('project_id', 'uuid', (c) => c.notNull())
+    .addColumn('organisation_id', 'uuid', (c) => c.notNull())
+    .addColumn('event_type', 'text', (c) => c.notNull())
+    .addColumn('event_version', 'integer', (c) => c.notNull().defaultTo(1))
+    .addColumn('occurred_at', 'timestamptz', (c) => c.notNull().defaultTo(sql`now()`))
+    .addColumn('actor_user_id', 'uuid', (c) => c.notNull())
+    .addColumn('idempotency_key', 'text', (c) => c.notNull())
+    .addColumn('payload', 'jsonb', (c) => c.notNull())
+    .addColumn('causation_id', 'uuid')
+    .addColumn('correlation_id', 'uuid')
+    .addUniqueConstraint('artifact_events_org_idempotency_unique', [
+      'organisation_id',
+      'idempotency_key',
+    ])
+    .execute();
+
+  await sql`
+    ALTER TABLE artifact_events ADD CONSTRAINT artifact_events_type_chk
+      CHECK (
+        event_type IN (
+          'artifact.created',
+          'artifact.updated',
+          'artifact.attached',
+          'artifact.reviewed',
+          'artifact.approved',
+          'artifact.rejected',
+          'artifact.superseded'
+        )
+      )
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE artifact_events ADD CONSTRAINT artifact_events_version_positive_chk
+      CHECK (event_version > 0)
+  `.execute(db);
+
+  await db.schema
+    .createIndex('artifact_events_artifact_occurred_idx')
+    .on('artifact_events')
+    .columns(['artifact_id', 'occurred_at'])
+    .execute();
+
+  await db.schema
+    .createIndex('artifact_events_project_occurred_idx')
+    .on('artifact_events')
+    .columns(['project_id', 'occurred_at'])
+    .execute();
+
+  await db.schema
+    .createIndex('artifact_events_organisation_idx')
+    .on('artifact_events')
+    .column('organisation_id')
+    .execute();
+
+  await sql`ALTER TABLE artifact_events ENABLE ROW LEVEL SECURITY`.execute(db);
+  await sql`ALTER TABLE artifact_events FORCE ROW LEVEL SECURITY`.execute(db);
+
+  await sql`
+    CREATE POLICY artifact_events_owner_read ON artifact_events
+      AS PERMISSIVE
+      FOR SELECT
+      USING (organisation_id = ${currentOrganisationId})
+  `.execute(db);
+
+  await sql`
+    CREATE POLICY artifact_events_owner_insert ON artifact_events
+      AS PERMISSIVE
+      FOR INSERT
+      WITH CHECK (organisation_id = ${currentOrganisationId})
+  `.execute(db);
+
+  await sql`
+    CREATE OR REPLACE FUNCTION prevent_artifact_events_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      RAISE EXCEPTION 'artifact_events is append-only';
+    END;
+    $$;
+  `.execute(db);
+
+  await sql`
+    CREATE TRIGGER artifact_events_no_update
+      BEFORE UPDATE ON artifact_events
+      FOR EACH ROW
+      EXECUTE FUNCTION prevent_artifact_events_mutation()
+  `.execute(db);
+
+  await sql`
+    CREATE TRIGGER artifact_events_no_delete
+      BEFORE DELETE ON artifact_events
+      FOR EACH ROW
+      EXECUTE FUNCTION prevent_artifact_events_mutation()
+  `.execute(db);
+}
+
+export async function down(_db?: Kysely<unknown>): Promise<void> {
+  throw new Error(
+    'down migrations are not supported. Roll back by reverting to a prior snapshot and re-running migrations forward.',
+  );
+}

--- a/packages/events-core/src/migrations/index.test.ts
+++ b/packages/events-core/src/migrations/index.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+import * as artifactEvents from './0001-artifact-events.js';
+import {
+  ARTIFACT_EVENTS_MIGRATION_ID,
+  EventsMigrationProvider,
+  eventsMigrationIds,
+} from './index.js';
+
+describe('events migration registry', () => {
+  it('registers artifact events as the first events migration', async () => {
+    const provider = new EventsMigrationProvider();
+    const migrations = await provider.getMigrations();
+
+    expect(eventsMigrationIds).toEqual([ARTIFACT_EVENTS_MIGRATION_ID]);
+    expect(migrations[ARTIFACT_EVENTS_MIGRATION_ID]).toBe(artifactEvents);
+    expect(migrations[ARTIFACT_EVENTS_MIGRATION_ID].up).toBeTypeOf('function');
+    expect(migrations[ARTIFACT_EVENTS_MIGRATION_ID].down).toBeTypeOf('function');
+  });
+
+  it('keeps events migrations forward-only', async () => {
+    await expect(artifactEvents.down()).rejects.toThrow('down migrations are not supported');
+  });
+
+  it('keeps artifact events append-only under tenant RLS', async () => {
+    const source = await readFile(new URL('./0001-artifact-events.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain('ALTER TABLE artifact_events ENABLE ROW LEVEL SECURITY');
+    expect(source).toContain('ALTER TABLE artifact_events FORCE ROW LEVEL SECURITY');
+    expect(source).toContain('CREATE POLICY artifact_events_owner_read');
+    expect(source).toContain('CREATE POLICY artifact_events_owner_insert');
+    expect(source).not.toContain('FOR UPDATE');
+    expect(source).not.toContain('FOR DELETE');
+    expect(source).toContain('CREATE TRIGGER artifact_events_no_update');
+    expect(source).toContain('CREATE TRIGGER artifact_events_no_delete');
+    expect(source).toContain('artifact_events_org_idempotency_unique');
+  });
+});

--- a/packages/events-core/src/migrations/index.ts
+++ b/packages/events-core/src/migrations/index.ts
@@ -1,0 +1,35 @@
+import { type Kysely, type Migration, Migrator, type MigrationProvider } from 'kysely';
+
+import * as artifactEvents from './0001-artifact-events.js';
+
+export const ARTIFACT_EVENTS_MIGRATION_ID = '0001-artifact-events';
+
+export const eventsMigrationIds = [ARTIFACT_EVENTS_MIGRATION_ID] as const;
+
+export type EventsMigrationId = (typeof eventsMigrationIds)[number];
+
+export class EventsMigrationProvider implements MigrationProvider {
+  async getMigrations(): Promise<Record<EventsMigrationId, Migration>> {
+    return {
+      [ARTIFACT_EVENTS_MIGRATION_ID]: artifactEvents,
+    };
+  }
+}
+
+export function createEventsMigrator(db: Kysely<unknown>): Migrator {
+  return new Migrator({
+    db,
+    provider: new EventsMigrationProvider(),
+    migrationTableName: 'events_migrations',
+    migrationLockTableName: 'events_migration_lock',
+  });
+}
+
+export async function migrateEventsToLatest(db: Kysely<unknown>): Promise<void> {
+  const migrator = createEventsMigrator(db);
+  const { error } = await migrator.migrateToLatest();
+
+  if (error) {
+    throw error;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,11 @@ importers:
 
   packages/design-system: {}
 
-  packages/events-core: {}
+  packages/events-core:
+    dependencies:
+      kysely:
+        specifier: ^0.27.5
+        version: 0.27.6
 
   packages/ipc-autopilot: {}
 


### PR DESCRIPTION
## Summary
- add typed artifact event append API owned by events-core
- add forward-only artifact_events migration with tenant RLS, insert/read policies, idempotency, and mutation-prevention triggers
- normalize compliance scanner paths so Windows and CI both honor the events-core allow-list

## Verification
- corepack pnpm lint
- corepack pnpm format:check
- corepack pnpm compliance:scan
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build

Closes #2