### PR TITLE
Add audited Agent Gateway boundary

### DIFF
--- a/packages/agent-gateway/src/index.test.ts
+++ b/packages/agent-gateway/src/index.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAuditableRequest,
+  createAgentGateway,
+  type AgentGatewayAuditEvent,
+  type AgentGatewayProviderClient,
+  type AgentGatewayRequest,
+} from './index.js';
+
+const requestedAt = new Date('2026-04-27T11:00:00.000Z');
+const completedAt = new Date('2026-04-27T11:00:01.000Z');
+
+function baseRequest(overrides: Partial<AgentGatewayRequest> = {}): AgentGatewayRequest {
+  return {
+    provider: 'local',
+    model: 'batios-test-model',
+    messages: [{ role: 'user', content: 'Summarise the site note.' }],
+    metadata: {
+      requestId: 'req_01',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      purpose: 'field-evidence-assist',
+      custodyScope: 'project-joint-custody',
+      policyTags: ['no-training', 'audit-required'],
+      retention: 'audit-log',
+      requestedAt,
+      traceId: 'trace_01',
+    },
+    ...overrides,
+  };
+}
+
+describe('agent gateway boundary', () => {
+  it('requires audit metadata before provider calls can be made', () => {
+    expect(() =>
+      assertAuditableRequest(
+        baseRequest({
+          messages: [],
+        }),
+      ),
+    ).toThrow('messages must contain at least one message');
+
+    expect(() =>
+      assertAuditableRequest(
+        baseRequest({
+          metadata: {
+            ...baseRequest().metadata,
+            policyTags: [],
+          },
+        }),
+      ),
+    ).toThrow('metadata.policyTags must contain at least one policy tag');
+  });
+
+  it('routes provider calls through policy and audit hooks', async () => {
+    const events: AgentGatewayAuditEvent[] = [];
+    const providerCalls: AgentGatewayRequest[] = [];
+    const provider: AgentGatewayProviderClient = {
+      async complete(request) {
+        providerCalls.push(request);
+        return {
+          requestId: 'provider-generated-id',
+          provider: 'local',
+          model: 'provider-model',
+          content: 'Evidence note summarised.',
+          usage: { inputTokens: 12, outputTokens: 6 },
+          completedAt,
+        };
+      },
+    };
+
+    const gateway = createAgentGateway({
+      providers: { local: provider, openai: undefined, anthropic: undefined, google: undefined },
+      auditSink: {
+        async record(event) {
+          events.push(event);
+        },
+      },
+      policy: {
+        async evaluate(request) {
+          return { allowed: request.metadata.custodyScope === 'project-joint-custody' };
+        },
+      },
+    });
+
+    const response = await gateway.complete(baseRequest());
+
+    expect(providerCalls).toHaveLength(1);
+    expect(response).toMatchObject({
+      requestId: 'req_01',
+      provider: 'local',
+      model: 'batios-test-model',
+      content: 'Evidence note summarised.',
+    });
+    expect(events.map((event) => event.outcome)).toEqual(['accepted', 'completed']);
+    expect(events[0]).toMatchObject({
+      requestId: 'req_01',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      purpose: 'field-evidence-assist',
+      custodyScope: 'project-joint-custody',
+      retention: 'audit-log',
+      traceId: 'trace_01',
+    });
+    expect(events[1]).toMatchObject({
+      outcome: 'completed',
+      completedAt,
+      usage: { inputTokens: 12, outputTokens: 6 },
+    });
+  });
+
+  it('audits rejected requests without calling the provider', async () => {
+    const events: AgentGatewayAuditEvent[] = [];
+    const providerCalls: AgentGatewayRequest[] = [];
+    const gateway = createAgentGateway({
+      providers: {
+        local: {
+          async complete(request) {
+            providerCalls.push(request);
+            throw new Error('should not call provider');
+          },
+        },
+        openai: undefined,
+        anthropic: undefined,
+        google: undefined,
+      },
+      auditSink: {
+        async record(event) {
+          events.push(event);
+        },
+      },
+      policy: {
+        async evaluate() {
+          return { allowed: false, reason: 'missing custody grant' };
+        },
+      },
+    });
+
+    await expect(gateway.complete(baseRequest())).rejects.toThrow('missing custody grant');
+
+    expect(providerCalls).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      outcome: 'rejected',
+      reason: 'missing custody grant',
+    });
+  });
+});

--- a/packages/agent-gateway/src/index.ts
+++ b/packages/agent-gateway/src/index.ts
@@ -1,1 +1,234 @@
 export const agentGatewayBoundary = 'agent-gateway';
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type AgentGatewayProvider = 'openai' | 'anthropic' | 'google' | 'local';
+
+export type AgentGatewayMessageRole = 'system' | 'user' | 'assistant' | 'tool';
+
+export interface AgentGatewayMessage {
+  role: AgentGatewayMessageRole;
+  content: string;
+}
+
+export interface AgentGatewayRequestMetadata {
+  requestId: string;
+  organisationId: string;
+  projectId?: string;
+  actorUserId: string;
+  purpose:
+    | 'field-evidence-assist'
+    | 'contract-review'
+    | 'payment-risk-review'
+    | 'qa-compliance'
+    | 'operator-support';
+  custodyScope: 'tenant-only' | 'project-joint-custody' | 'public-reference';
+  policyTags: readonly string[];
+  retention: 'ephemeral' | 'audit-log' | 'case-record';
+  requestedAt: Date;
+  traceId?: string;
+}
+
+export interface AgentGatewayRequest {
+  provider: AgentGatewayProvider;
+  model: string;
+  messages: readonly AgentGatewayMessage[];
+  metadata: AgentGatewayRequestMetadata;
+  temperature?: number;
+  maxOutputTokens?: number;
+  responseFormat?: 'text' | 'json';
+}
+
+export interface AgentGatewayUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface AgentGatewayResponse {
+  requestId: string;
+  provider: AgentGatewayProvider;
+  model: string;
+  content: string;
+  usage?: AgentGatewayUsage;
+  providerResponseId?: string;
+  completedAt: Date;
+}
+
+export interface AgentGatewayAuditEvent {
+  requestId: string;
+  organisationId: string;
+  projectId?: string;
+  actorUserId: string;
+  provider: AgentGatewayProvider;
+  model: string;
+  purpose: AgentGatewayRequestMetadata['purpose'];
+  custodyScope: AgentGatewayRequestMetadata['custodyScope'];
+  policyTags: readonly string[];
+  retention: AgentGatewayRequestMetadata['retention'];
+  traceId?: string;
+  requestedAt: Date;
+  completedAt?: Date;
+  outcome: 'accepted' | 'rejected' | 'completed' | 'failed';
+  reason?: string;
+  usage?: AgentGatewayUsage;
+}
+
+export interface AgentGatewayProviderClient {
+  complete(request: AgentGatewayRequest): Promise<AgentGatewayResponse>;
+}
+
+export interface AgentGatewayAuditSink {
+  record(event: AgentGatewayAuditEvent): Promise<void>;
+}
+
+export interface AgentGatewayPolicy {
+  evaluate(request: AgentGatewayRequest): Promise<AgentGatewayPolicyDecision>;
+}
+
+export interface AgentGatewayPolicyDecision {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface AgentGateway {
+  complete(request: AgentGatewayRequest): Promise<AgentGatewayResponse>;
+}
+
+export interface CreateAgentGatewayOptions {
+  providers: Readonly<Record<AgentGatewayProvider, AgentGatewayProviderClient | undefined>>;
+  auditSink: AgentGatewayAuditSink;
+  policy?: AgentGatewayPolicy;
+  now?: () => Date;
+}
+
+const allowAllPolicy: AgentGatewayPolicy = {
+  async evaluate(): Promise<AgentGatewayPolicyDecision> {
+    return { allowed: true };
+  },
+};
+
+export function createAgentGateway(options: CreateAgentGatewayOptions): AgentGateway {
+  const policy = options.policy ?? allowAllPolicy;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async complete(request) {
+      assertAuditableRequest(request);
+
+      const provider = options.providers[request.provider];
+      if (provider === undefined) {
+        const reason = `provider ${request.provider} is not configured`;
+        await options.auditSink.record(toAuditEvent(request, 'rejected', { reason }));
+        throw new Error(reason);
+      }
+
+      const decision = await policy.evaluate(request);
+      if (!decision.allowed) {
+        const reason = decision.reason ?? 'request rejected by agent gateway policy';
+        await options.auditSink.record(toAuditEvent(request, 'rejected', { reason }));
+        throw new Error(reason);
+      }
+
+      await options.auditSink.record(toAuditEvent(request, 'accepted'));
+
+      try {
+        const response = await provider.complete(request);
+        const completedAt = response.completedAt ?? now();
+        const completedAudit: Pick<AgentGatewayAuditEvent, 'completedAt' | 'usage'> = {
+          completedAt,
+        };
+
+        if (response.usage !== undefined) {
+          completedAudit.usage = response.usage;
+        }
+
+        await options.auditSink.record(toAuditEvent(request, 'completed', completedAudit));
+
+        return {
+          ...response,
+          requestId: request.metadata.requestId,
+          provider: request.provider,
+          model: request.model,
+          completedAt,
+        };
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : 'provider request failed';
+        await options.auditSink.record(toAuditEvent(request, 'failed', { reason }));
+        throw error;
+      }
+    },
+  };
+}
+
+export function assertAuditableRequest(request: AgentGatewayRequest): void {
+  assertPresent(request.metadata.requestId, 'metadata.requestId');
+  assertPresent(request.metadata.organisationId, 'metadata.organisationId');
+  assertPresent(request.metadata.actorUserId, 'metadata.actorUserId');
+  assertPresent(request.metadata.purpose, 'metadata.purpose');
+  assertPresent(request.metadata.custodyScope, 'metadata.custodyScope');
+  assertPresent(request.metadata.retention, 'metadata.retention');
+  assertPresent(request.provider, 'provider');
+  assertPresent(request.model, 'model');
+
+  if (request.messages.length === 0) {
+    throw new Error('messages must contain at least one message');
+  }
+
+  if (request.metadata.policyTags.length === 0) {
+    throw new Error('metadata.policyTags must contain at least one policy tag');
+  }
+}
+
+function assertPresent(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+}
+
+function toAuditEvent(
+  request: AgentGatewayRequest,
+  outcome: AgentGatewayAuditEvent['outcome'],
+  extras: Pick<AgentGatewayAuditEvent, 'completedAt' | 'reason' | 'usage'> = {},
+): AgentGatewayAuditEvent {
+  const event: AgentGatewayAuditEvent = {
+    requestId: request.metadata.requestId,
+    organisationId: request.metadata.organisationId,
+    actorUserId: request.metadata.actorUserId,
+    provider: request.provider,
+    model: request.model,
+    purpose: request.metadata.purpose,
+    custodyScope: request.metadata.custodyScope,
+    policyTags: request.metadata.policyTags,
+    retention: request.metadata.retention,
+    requestedAt: request.metadata.requestedAt,
+    outcome,
+  };
+
+  if (request.metadata.projectId !== undefined) {
+    event.projectId = request.metadata.projectId;
+  }
+
+  if (request.metadata.traceId !== undefined) {
+    event.traceId = request.metadata.traceId;
+  }
+
+  if (extras.completedAt !== undefined) {
+    event.completedAt = extras.completedAt;
+  }
+
+  if (extras.reason !== undefined) {
+    event.reason = extras.reason;
+  }
+
+  if (extras.usage !== undefined) {
+    event.usage = extras.usage;
+  }
+
+  return event;
+}


### PR DESCRIPTION
## Summary
- add provider-agnostic Agent Gateway request, response, metadata, policy, provider, and audit interfaces
- require tenant/user/purpose/custody/policy metadata before provider calls
- route completions through policy and audit hooks with tests for accepted and rejected requests

## Verification
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm format:check
- corepack pnpm compliance:scan

Closes #4