### PR TITLE
Strengthen QA and compliance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,5 @@ jobs:
       - run: pnpm -r test
         env:
           BATIOS_TEST_DATABASE_URL: postgres://batios:batios@localhost:5432/batios_test
+      - run: pnpm qa:harness
       - run: node compliance-mapper-stub.mjs

--- a/compliance-mapper-stub.mjs
+++ b/compliance-mapper-stub.mjs
@@ -1,38 +1,41 @@
 #!/usr/bin/env node
 /**
- * Compliance Mapper stub (Week 0 version).
+ * Compliance Mapper stub (foundation version).
  *
  * Regex-based scan for common architectural violations. This is deliberately
- * crude; a real Compliance Mapper agent with AST parsing and database-aware RLS
- * tests must replace it later.
- *
- * What this stub catches:
- *   - Direct LLM SDK imports or require() calls outside packages/agent-gateway
- *   - Direct INSERT/UPDATE/DELETE on artifact_events outside packages/events-core
- *   - localStorage or sessionStorage use
- *   - Migration files that create tenant-like tables but do not enable RLS and
- *     define at least one CREATE POLICY block
- *
- * What this stub does NOT catch:
- *   - Semantic RLS errors, policy recursion, or wrong policy predicates
- *   - Dynamic imports, obfuscated imports, generated code, or comments/strings
- *   - Cross-tenant retrieval leakage in agent calls
- *   - Methodology-reference validation gaps
- *   - Cascade atomicity violations
+ * conservative; a real Compliance Mapper agent with AST parsing, dataflow, and
+ * database-aware RLS tests should replace it later.
  */
 
+import { pathToFileURL } from 'node:url';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { extname, join, relative } from 'node:path';
+import { extname, join, relative, resolve } from 'node:path';
 
-const REPO_ROOT = process.cwd();
-const violations = [];
+const DEFAULT_REPO_ROOT = process.cwd();
 
-const RULES = [
+export const RULES = [
   {
     id: 'LLM_SDK_OUTSIDE_GATEWAY',
     description: 'Direct LLM SDK import outside packages/agent-gateway',
     pattern:
       /(?:from\s+['"]|import\(['"]|require\(['"])(@anthropic-ai\/sdk|openai|@google\/generative-ai)['"]\)?/,
+    allowedPath: /^packages\/agent-gateway\//,
+    severity: 'REJECT',
+    extensions: ['.ts', '.tsx', '.js', '.mjs', '.cjs'],
+  },
+  {
+    id: 'LLM_PROVIDER_HTTP_OUTSIDE_GATEWAY',
+    description: 'Direct LLM provider HTTP call outside packages/agent-gateway',
+    pattern:
+      /https:\/\/api\.(openai|anthropic)\.com|https:\/\/generativelanguage\.googleapis\.com/i,
+    allowedPath: /^packages\/agent-gateway\//,
+    severity: 'REJECT',
+    extensions: ['.ts', '.tsx', '.js', '.mjs', '.cjs'],
+  },
+  {
+    id: 'LLM_PROVIDER_SECRET_OUTSIDE_GATEWAY',
+    description: 'Direct LLM provider secret access outside packages/agent-gateway',
+    pattern: /process\.env\.(OPENAI_API_KEY|ANTHROPIC_API_KEY|GOOGLE_GENERATIVE_AI_API_KEY)\b/,
     allowedPath: /^packages\/agent-gateway\//,
     severity: 'REJECT',
     extensions: ['.ts', '.tsx', '.js', '.mjs', '.cjs'],
@@ -56,24 +59,79 @@ const RULES = [
   },
 ];
 
-function walk(dir, callback) {
+const IGNORED_ENTRIES = new Set(['node_modules', 'dist', '.next', '.git', 'scratch', 'coverage']);
+
+export function scanRepository(repoRoot = DEFAULT_REPO_ROOT) {
+  const root = resolve(repoRoot);
+  const violations = [];
+
+  walk(root, root, (fullPath, relPath) => {
+    const extension = extname(relPath);
+    let content;
+    try {
+      content = readFileSync(fullPath, 'utf8');
+    } catch {
+      return;
+    }
+
+    for (const rule of RULES) {
+      if (!rule.extensions.includes(extension)) continue;
+      if (rule.allowedPath && rule.allowedPath.test(relPath)) continue;
+
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (rule.pattern.test(lines[i])) {
+          addViolation(violations, {
+            rule: rule.id,
+            severity: rule.severity,
+            description: rule.description,
+            file: relPath,
+            line: i + 1,
+            snippet: lines[i],
+          });
+        }
+      }
+    }
+
+    if (isMigrationPath(relPath) && /createTable\(|CREATE\s+TABLE/i.test(content)) {
+      const appearsTenantScoped = /organisation_id|tenant_hash|project_id/i.test(content);
+      const enablesRls = /ENABLE\s+ROW\s+LEVEL\s+SECURITY/i.test(content);
+      const forcesRls = /FORCE\s+ROW\s+LEVEL\s+SECURITY/i.test(content);
+      const hasPolicy = /CREATE\s+POLICY/i.test(content);
+
+      if (appearsTenantScoped && (!enablesRls || !forcesRls || !hasPolicy)) {
+        addViolation(violations, {
+          rule: 'TENANT_MIGRATION_WITHOUT_RLS_BLOCK',
+          severity: 'BLOCK',
+          description:
+            'Migration appears tenant-scoped but does not include ENABLE RLS, FORCE RLS, and at least one CREATE POLICY block',
+          file: relPath,
+          snippet: 'tenant-like migration missing complete RLS block',
+        });
+      }
+    }
+  });
+
+  return {
+    clean: violations.length === 0,
+    violations,
+    hasBlock: violations.some((violation) => violation.severity === 'BLOCK'),
+    hasReject: violations.some((violation) => violation.severity === 'REJECT'),
+  };
+}
+
+function walk(root, dir, callback) {
   for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry);
-    const rel = relative(REPO_ROOT, full).replaceAll('\\', '/');
-    if (
-      entry === 'node_modules' ||
-      entry === 'dist' ||
-      entry === '.next' ||
-      entry === '.git' ||
-      entry === 'scratch' ||
-      entry.startsWith('.')
-    ) {
+    if (IGNORED_ENTRIES.has(entry) || entry.startsWith('.')) {
       continue;
     }
 
+    const full = join(dir, entry);
+    const rel = relative(root, full).replaceAll('\\', '/');
     const stat = statSync(full);
+
     if (stat.isDirectory()) {
-      walk(full, callback);
+      walk(root, full, callback);
     } else {
       callback(full, rel);
     }
@@ -84,81 +142,59 @@ function isMigrationPath(relPath) {
   return /(^|\/)migrations\//.test(relPath) || /^\d{4}[-_].*\.(ts|sql)$/.test(relPath);
 }
 
-function addViolation({ rule, severity, description, file, line = 1, snippet = '' }) {
-  violations.push({ rule, severity, description, file, line, snippet: snippet.trim().slice(0, 120) });
+function addViolation(violations, { rule, severity, description, file, line = 1, snippet = '' }) {
+  violations.push({
+    rule,
+    severity,
+    description,
+    file,
+    line,
+    snippet: snippet.trim().slice(0, 120),
+  });
 }
 
-walk(REPO_ROOT, (fullPath, relPath) => {
-  const extension = extname(relPath);
-  let content;
-  try {
-    content = readFileSync(fullPath, 'utf8');
-  } catch {
-    return;
+export function formatScanResult(result) {
+  if (result.clean) {
+    return 'compliance-mapper: clean\n';
   }
 
-  for (const rule of RULES) {
-    if (!rule.extensions.includes(extension)) continue;
-    if (rule.allowedPath && rule.allowedPath.test(relPath)) continue;
-
-    const lines = content.split('\n');
-    for (let i = 0; i < lines.length; i++) {
-      if (rule.pattern.test(lines[i])) {
-        addViolation({
-          rule: rule.id,
-          severity: rule.severity,
-          description: rule.description,
-          file: relPath,
-          line: i + 1,
-          snippet: lines[i],
-        });
-      }
-    }
+  const lines = ['compliance-mapper: violations found', ''];
+  for (const violation of result.violations) {
+    lines.push(`[${violation.severity}] ${violation.rule}`);
+    lines.push(`  ${violation.file}:${violation.line}`);
+    lines.push(`  ${violation.description}`);
+    lines.push(`  > ${violation.snippet}`);
+    lines.push('');
   }
 
-  if (isMigrationPath(relPath) && /createTable\(|CREATE\s+TABLE/i.test(content)) {
-    const appearsTenantScoped = /organisation_id|tenant_hash|project_id/i.test(content);
-    const enablesRls = /ENABLE\s+ROW\s+LEVEL\s+SECURITY/i.test(content);
-    const forcesRls = /FORCE\s+ROW\s+LEVEL\s+SECURITY/i.test(content);
-    const hasPolicy = /CREATE\s+POLICY/i.test(content);
-
-    if (appearsTenantScoped && (!enablesRls || !forcesRls || !hasPolicy)) {
-      addViolation({
-        rule: 'TENANT_MIGRATION_WITHOUT_RLS_BLOCK',
-        severity: 'BLOCK',
-        description:
-          'Migration appears tenant-scoped but does not include ENABLE RLS, FORCE RLS, and at least one CREATE POLICY block',
-        file: relPath,
-        snippet: 'tenant-like migration missing complete RLS block',
-      });
-    }
+  if (result.hasBlock) {
+    lines.push('BLOCK-class violation detected. No override path. Remediate before merging.');
+  } else if (result.hasReject) {
+    lines.push(
+      'REJECT-class violation detected. Override via ADR-0005 two-signer protocol or remediate.',
+    );
   }
-});
 
-if (violations.length === 0) {
-  console.log('compliance-mapper: clean');
-  process.exit(0);
+  return `${lines.join('\n')}\n`;
 }
 
-console.error('compliance-mapper: violations found');
-console.error('');
-for (const v of violations) {
-  console.error(`[${v.severity}] ${v.rule}`);
-  console.error(`  ${v.file}:${v.line}`);
-  console.error(`  ${v.description}`);
-  console.error(`  > ${v.snippet}`);
-  console.error('');
+function exitCodeFor(result) {
+  if (result.hasBlock) return 2;
+  if (result.hasReject) return 1;
+  return 0;
 }
 
-const hasBlock = violations.some((v) => v.severity === 'BLOCK');
-const hasReject = violations.some((v) => v.severity === 'REJECT');
+const isCli = import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
 
-if (hasBlock) {
-  console.error('BLOCK-class violation detected. No override path. Remediate before merging.');
-  process.exit(2);
+if (isCli) {
+  const result = scanRepository(process.argv[2] ?? DEFAULT_REPO_ROOT);
+  const output = formatScanResult(result);
+
+  if (result.clean) {
+    process.stdout.write(output);
+  } else {
+    process.stderr.write(output);
+  }
+
+  process.exit(exitCodeFor(result));
 }
-if (hasReject) {
-  console.error('REJECT-class violation detected. Override via ADR-0005 two-signer protocol or remediate.');
-  process.exit(1);
-}
-process.exit(0);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean": "corepack pnpm -r clean && node -e \"require('node:fs').rmSync('node_modules',{recursive:true,force:true})\"",
     "format": "prettier --write \"**/*.{ts,tsx,json,md,yaml,yml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json,md,yaml,yml}\"",
-    "qa:harness": "corepack pnpm --filter @batios/qa-harness exec qa",
+    "qa:harness": "node packages/qa-harness/dist/index.js",
     "compliance:scan": "node compliance-mapper-stub.mjs"
   },
   "dependencies": {

--- a/packages/qa-harness/package.json
+++ b/packages/qa-harness/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "qa": "node dist/index.js",
     "test": "vitest run --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests --dir test/integration",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""

--- a/packages/qa-harness/src/index.test.ts
+++ b/packages/qa-harness/src/index.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { PRE_PR_CHECKS, runQaHarness } from './index.js';
+
+const complianceMapperPath = resolve(process.cwd(), '../../compliance-mapper-stub.mjs');
+const llmImportSource = `import OpenAI from '${'open' + 'ai'}';`;
+const llmSecretSource = `export const key = process.env.${'OPENAI' + '_API_KEY'};`;
+const artifactWriteSource = `return db.insertInto('${'artifact' + '_events'}').values({});`;
+
+function withFixture(files: Record<string, string>, callback: (root: string) => void): void {
+  const root = mkdtempSync(join(tmpdir(), 'batios-compliance-'));
+
+  try {
+    for (const [path, content] of Object.entries(files)) {
+      const fullPath = join(root, path);
+      mkdirSync(resolve(fullPath, '..'), { recursive: true });
+      writeFileSync(fullPath, content);
+    }
+
+    callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function runCompliance(root: string): { status: number; output: string } {
+  try {
+    const output = execFileSync(process.execPath, [complianceMapperPath, root], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, output };
+  } catch (error) {
+    const failure = error as { status: number; stderr: Buffer; stdout: Buffer };
+    return {
+      status: failure.status,
+      output: `${failure.stdout.toString()}${failure.stderr.toString()}`,
+    };
+  }
+}
+
+describe('qa harness', () => {
+  it('declares the required pre-PR checks', () => {
+    expect(PRE_PR_CHECKS.map((check) => check.id)).toEqual([
+      'build',
+      'lint',
+      'typecheck',
+      'test',
+      'format',
+      'compliance',
+    ]);
+  });
+
+  it('validates the current repo QA script and CI compliance wiring', () => {
+    const result = runQaHarness(resolve(process.cwd(), '../..'));
+
+    expect(result.ok).toBe(true);
+    expect(result.missingScripts).toEqual([]);
+    expect(result.ciRunsComplianceScan).toBe(true);
+  });
+
+  it('blocks direct LLM SDK and provider secret usage outside the agent gateway', () => {
+    withFixture(
+      {
+        'apps/admin/app/page.tsx': `
+          ${llmImportSource}
+          ${llmSecretSource}
+        `,
+      },
+      (root) => {
+        const result = runCompliance(root);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('LLM_SDK_OUTSIDE_GATEWAY');
+        expect(result.output).toContain('LLM_PROVIDER_SECRET_OUTSIDE_GATEWAY');
+      },
+    );
+  });
+
+  it('blocks direct artifact event writes outside events-core', () => {
+    withFixture(
+      {
+        'packages/api-client/src/index.ts': `
+          export function write(db) {
+            ${artifactWriteSource}
+          }
+        `,
+      },
+      (root) => {
+        const result = runCompliance(root);
+
+        expect(result.status).toBe(2);
+        expect(result.output).toContain('DIRECT_ARTIFACT_EVENTS_WRITE');
+      },
+    );
+  });
+
+  it('blocks tenant-scoped migrations without a complete RLS block', () => {
+    withFixture(
+      {
+        'packages/platform-core/src/migrations/0002-projects.ts': `
+          export async function up(db) {
+            await db.schema.createTable('unsafe_projects')
+              .addColumn('project_id', 'uuid')
+              .addColumn('organisation_id', 'uuid')
+              .execute();
+          }
+        `,
+      },
+      (root) => {
+        const result = runCompliance(root);
+
+        expect(result.status).toBe(2);
+        expect(result.output).toContain('TENANT_MIGRATION_WITHOUT_RLS_BLOCK');
+      },
+    );
+  });
+
+  it('allows owned gateway and events-core boundary operations', () => {
+    withFixture(
+      {
+        'packages/agent-gateway/src/provider.ts': `
+          ${llmImportSource}
+          ${llmSecretSource}
+        `,
+        'packages/events-core/src/artifact-events.ts': `
+          export function append(db) {
+            ${artifactWriteSource}
+          }
+        `,
+      },
+      (root) => {
+        const result = runCompliance(root);
+
+        expect(result.status).toBe(0);
+        expect(result.output).toContain('compliance-mapper: clean');
+      },
+    );
+  });
+});

--- a/packages/qa-harness/src/index.ts
+++ b/packages/qa-harness/src/index.ts
@@ -1,3 +1,89 @@
-export function runQaHarness(): string {
-  return 'qa-harness-ready';
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface QaHarnessCheck {
+  id: string;
+  command: string;
+  required: boolean;
+}
+
+export interface QaHarnessResult {
+  ok: boolean;
+  repoRoot: string;
+  checks: readonly QaHarnessCheck[];
+  missingScripts: readonly string[];
+  ciRunsComplianceScan: boolean;
+}
+
+export const PRE_PR_CHECKS: readonly QaHarnessCheck[] = [
+  { id: 'build', command: 'corepack pnpm build', required: true },
+  { id: 'lint', command: 'corepack pnpm lint', required: true },
+  { id: 'typecheck', command: 'corepack pnpm typecheck', required: true },
+  { id: 'test', command: 'corepack pnpm test', required: true },
+  { id: 'format', command: 'corepack pnpm format:check', required: true },
+  { id: 'compliance', command: 'corepack pnpm compliance:scan', required: true },
+];
+
+const scriptNamesByCheckId: Readonly<Record<string, string>> = {
+  build: 'build',
+  lint: 'lint',
+  typecheck: 'typecheck',
+  test: 'test',
+  format: 'format:check',
+  compliance: 'compliance:scan',
+};
+
+export function runQaHarness(
+  repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..'),
+): QaHarnessResult {
+  const packageJson = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  const scripts = packageJson.scripts ?? {};
+  const missingScripts = PRE_PR_CHECKS.map((check) => check.id).filter((id) => {
+    const scriptName = scriptNamesByCheckId[id] ?? id;
+    return scripts[scriptName] === undefined;
+  });
+
+  const ciWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+  const ciRunsComplianceScan = /compliance(:scan|-mapper-stub\.mjs)/.test(ciWorkflow);
+
+  return {
+    ok: missingScripts.length === 0 && ciRunsComplianceScan,
+    repoRoot,
+    checks: PRE_PR_CHECKS,
+    missingScripts,
+    ciRunsComplianceScan,
+  };
+}
+
+export function formatQaHarnessResult(result: QaHarnessResult): string {
+  const lines = ['BatiOS QA harness', '', 'Required pre-PR checks:'];
+
+  for (const check of result.checks) {
+    lines.push(`- ${check.command}`);
+  }
+
+  lines.push('');
+  lines.push(`CI compliance scan: ${result.ciRunsComplianceScan ? 'configured' : 'missing'}`);
+
+  if (result.missingScripts.length > 0) {
+    lines.push(`Missing package scripts: ${result.missingScripts.join(', ')}`);
+  }
+
+  lines.push(`Status: ${result.ok ? 'ready' : 'blocked'}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function main(): void {
+  const result = runQaHarness();
+  process.stdout.write(formatQaHarnessResult(result));
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
 }


### PR DESCRIPTION
## Summary
- turn qa:harness into a concrete pre-PR gate entrypoint
- make the compliance mapper reusable as a scanner CLI with a target root
- add tests that prove current architecture violations are caught for LLM usage, provider secrets, artifact event writes, and tenant migrations without RLS
- run qa:harness in CI before the compliance scan

## Verification
- corepack pnpm --filter @batios/qa-harness typecheck
- corepack pnpm --filter @batios/qa-harness test
- corepack pnpm --filter @batios/qa-harness lint
- corepack pnpm --filter @batios/qa-harness build
- corepack pnpm qa:harness
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm format:check
- corepack pnpm compliance:scan

Closes #5