### PR TITLE
Build operational dashboard shells

### DIFF
--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -1,3 +1,56 @@
+import { DashboardShell } from '@batios/design-system';
+
 export default function Page() {
-  return <main>BatiOS Admin</main>;
+  return (
+    <DashboardShell
+      tone="admin"
+      product="BatiOS Admin"
+      title="Platform operations console"
+      subtitle="Manage tenant readiness, access controls, compliance posture, and operational exceptions from one controlled workspace."
+      primaryQueueTitle="Platform operations queue"
+      metrics={[
+        { label: 'Organisations', value: '31', detail: '6 pending onboarding' },
+        { label: 'Access reviews', value: '14', detail: 'Due this week' },
+        { label: 'Compliance alerts', value: '3', detail: 'No critical rejects' },
+        { label: 'Open support', value: '19', detail: 'Median age 7h' },
+      ]}
+      primaryQueue={[
+        {
+          title: 'Approve employer organisation setup',
+          meta: 'Ghana Highway Authority workspace requires final role mapping',
+          status: 'Access',
+        },
+        {
+          title: 'Review cross-project custody grant',
+          meta: 'External engineer requested read access on two active projects',
+          status: 'Policy',
+        },
+        {
+          title: 'Resolve failed evidence sync report',
+          meta: 'Field device EV-1048 submitted duplicate idempotency key',
+          status: 'Support',
+        },
+      ]}
+      decisions={[
+        { label: 'Confirm onboarding roles', owner: 'Platform admin', due: 'Today' },
+        { label: 'Approve external custody access', owner: 'Compliance lead', due: '24h' },
+        { label: 'Triage sync exception', owner: 'Support lead', due: 'Today' },
+      ]}
+    >
+      <section className="batios-dashboard__workspace" aria-label="Admin workspace shortcuts">
+        <article className="batios-dashboard__workspace-card">
+          <strong>Tenant onboarding</strong>
+          <p>Provision organisations, users, projects, and custody policies with audit context.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Access governance</strong>
+          <p>Review role grants, project parties, and exceptional access requests.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Compliance monitor</strong>
+          <p>Track architectural gates, support incidents, and evidence integrity alerts.</p>
+        </article>
+      </section>
+    </DashboardShell>
+  );
 }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,6 +14,7 @@
     "clean": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\""
   },
   "dependencies": {
+    "@batios/design-system": "workspace:*",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/pm-dashboard/app/page.tsx
+++ b/apps/pm-dashboard/app/page.tsx
@@ -1,3 +1,56 @@
+import { DashboardShell } from '@batios/design-system';
+
 export default function Page() {
-  return <main>BatiOS PM Dashboard</main>;
+  return (
+    <DashboardShell
+      tone="pm"
+      product="BatiOS PM"
+      title="Project command center"
+      subtitle="Track site progress, evidence readiness, approvals, and payment blockers across active public works packages."
+      primaryQueueTitle="Evidence awaiting PM action"
+      metrics={[
+        { label: 'Active projects', value: '12', detail: '3 with critical blockers' },
+        { label: 'Evidence packets', value: '48', detail: '11 awaiting review' },
+        { label: 'Payment holds', value: '7', detail: 'GHS 2.4M under review' },
+        { label: 'SLA risk', value: '5', detail: 'Due within 48 hours' },
+      ]}
+      primaryQueue={[
+        {
+          title: 'Kasoa drainage Lot A',
+          meta: 'Culvert rebar evidence needs PM acceptance before concrete pour',
+          status: 'Review',
+        },
+        {
+          title: 'Tamale feeder road Section 2',
+          meta: 'QS variation note attached; employer response pending',
+          status: 'Blocked',
+        },
+        {
+          title: 'Cape Coast market access road',
+          meta: 'Field packet complete; payment certificate can be drafted',
+          status: 'Ready',
+        },
+      ]}
+      decisions={[
+        { label: 'Approve Lot A pour readiness', owner: 'PM lead', due: 'Today' },
+        { label: 'Escalate delayed employer sign-off', owner: 'Regional director', due: '24h' },
+        { label: 'Release QS for certificate draft', owner: 'Project controller', due: 'Tomorrow' },
+      ]}
+    >
+      <section className="batios-dashboard__workspace" aria-label="PM workspace shortcuts">
+        <article className="batios-dashboard__workspace-card">
+          <strong>Evidence review lane</strong>
+          <p>Open packets sorted by contract item, custody status, and approval deadline.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Payment readiness</strong>
+          <p>Compare certified work, disputed quantities, and unresolved evidence gaps.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Project health</strong>
+          <p>Scan schedule risk, unresolved RFIs, and contract milestones by project.</p>
+        </article>
+      </section>
+    </DashboardShell>
+  );
 }

--- a/apps/pm-dashboard/package.json
+++ b/apps/pm-dashboard/package.json
@@ -14,6 +14,7 @@
     "clean": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\""
   },
   "dependencies": {
+    "@batios/design-system": "workspace:*",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/qs-dashboard/app/page.tsx
+++ b/apps/qs-dashboard/app/page.tsx
@@ -1,3 +1,56 @@
+import { DashboardShell } from '@batios/design-system';
+
 export default function Page() {
-  return <main>BatiOS QS Dashboard</main>;
+  return (
+    <DashboardShell
+      tone="qs"
+      product="BatiOS QS"
+      title="Quantity verification desk"
+      subtitle="Review measured work, reconcile field evidence, and prepare certificate-ready quantities without losing custody context."
+      primaryQueueTitle="Measurement checks"
+      metrics={[
+        { label: 'Bills in review', value: '9', detail: 'Across 5 projects' },
+        { label: 'Variance flags', value: '16', detail: '4 above threshold' },
+        { label: 'Ready for cert', value: '22', detail: 'Items with complete evidence' },
+        { label: 'Pending field notes', value: '8', detail: 'Need supervisor clarification' },
+      ]}
+      primaryQueue={[
+        {
+          title: 'Drainage excavation chainage 2+450',
+          meta: 'Measured 148m vs contract 136m; evidence packet complete',
+          status: 'Variance',
+        },
+        {
+          title: 'Culvert reinforcement Lot A-14',
+          meta: 'Spacing photos and delivery note ready for quantity sign-off',
+          status: 'Ready',
+        },
+        {
+          title: 'Concrete pour ticket reconciliation',
+          meta: 'Two delivery notes missing supplier stamp',
+          status: 'Clarify',
+        },
+      ]}
+      decisions={[
+        { label: 'Accept excavation variance', owner: 'Senior QS', due: 'Today' },
+        { label: 'Request stamped delivery note', owner: 'Site QS', due: '24h' },
+        { label: 'Package certificate draft', owner: 'Commercial lead', due: 'Tomorrow' },
+      ]}
+    >
+      <section className="batios-dashboard__workspace" aria-label="QS workspace shortcuts">
+        <article className="batios-dashboard__workspace-card">
+          <strong>Measurement book</strong>
+          <p>Work items grouped by bill item, chainage, evidence completeness, and variance.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Evidence match</strong>
+          <p>Spot missing photos, notes, and delivery records before certification.</p>
+        </article>
+        <article className="batios-dashboard__workspace-card">
+          <strong>Certificate prep</strong>
+          <p>Build a clean payment certificate queue from accepted measured work.</p>
+        </article>
+      </section>
+    </DashboardShell>
+  );
 }

--- a/apps/qs-dashboard/package.json
+++ b/apps/qs-dashboard/package.json
@@ -14,6 +14,7 @@
     "clean": "node -e \"require('node:fs').rmSync('.next',{recursive:true,force:true})\""
   },
   "dependencies": {
+    "@batios/design-system": "workspace:*",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -13,5 +13,8 @@
     "test": "vitest run --passWithNoTests",
     "test:integration": "vitest run --passWithNoTests --dir test/integration",
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  },
+  "dependencies": {
+    "react": "^19.0.0"
   }
 }

--- a/packages/design-system/src/dashboard-shell.tsx
+++ b/packages/design-system/src/dashboard-shell.tsx
@@ -1,0 +1,414 @@
+import type { ReactNode } from 'react';
+
+export type DashboardTone = 'admin' | 'pm' | 'qs';
+
+export interface DashboardMetric {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export interface DashboardWorkItem {
+  title: string;
+  meta: string;
+  status: string;
+}
+
+export interface DashboardDecision {
+  label: string;
+  owner: string;
+  due: string;
+}
+
+export interface DashboardShellProps {
+  tone: DashboardTone;
+  product: string;
+  title: string;
+  subtitle: string;
+  metrics: readonly DashboardMetric[];
+  primaryQueueTitle: string;
+  primaryQueue: readonly DashboardWorkItem[];
+  decisions: readonly DashboardDecision[];
+  children?: ReactNode;
+}
+
+export function DashboardShell({
+  tone,
+  product,
+  title,
+  subtitle,
+  metrics,
+  primaryQueueTitle,
+  primaryQueue,
+  decisions,
+  children,
+}: DashboardShellProps) {
+  return (
+    <main className={`batios-dashboard batios-dashboard--${tone}`}>
+      <style>{dashboardShellCss}</style>
+
+      <section className="batios-dashboard__topbar" aria-label={`${product} overview`}>
+        <div>
+          <p className="batios-dashboard__eyebrow">{product}</p>
+          <h1>{title}</h1>
+          <p className="batios-dashboard__subtitle">{subtitle}</p>
+        </div>
+        <div className="batios-dashboard__status" aria-label="Workspace status">
+          <span aria-hidden="true" />
+          Live workspace
+        </div>
+      </section>
+
+      <section className="batios-dashboard__metrics" aria-label="Operational metrics">
+        {metrics.map((metric) => (
+          <article key={metric.label} className="batios-dashboard__metric">
+            <span>{metric.label}</span>
+            <strong>{metric.value}</strong>
+            <small>{metric.detail}</small>
+          </article>
+        ))}
+      </section>
+
+      <section className="batios-dashboard__grid" aria-label="Operational work">
+        <article className="batios-dashboard__panel batios-dashboard__panel--wide">
+          <div className="batios-dashboard__panel-heading">
+            <div>
+              <p className="batios-dashboard__eyebrow">Primary queue</p>
+              <h2>{primaryQueueTitle}</h2>
+            </div>
+            <span>{primaryQueue.length} active</span>
+          </div>
+          <ol className="batios-dashboard__queue">
+            {primaryQueue.map((item) => (
+              <li key={item.title}>
+                <div>
+                  <strong>{item.title}</strong>
+                  <span>{item.meta}</span>
+                </div>
+                <mark>{item.status}</mark>
+              </li>
+            ))}
+          </ol>
+        </article>
+
+        <aside className="batios-dashboard__panel">
+          <div className="batios-dashboard__panel-heading">
+            <div>
+              <p className="batios-dashboard__eyebrow">Decisions</p>
+              <h2>Needs attention</h2>
+            </div>
+          </div>
+          <dl className="batios-dashboard__decisions">
+            {decisions.map((decision) => (
+              <div key={decision.label}>
+                <dt>{decision.label}</dt>
+                <dd>
+                  {decision.owner} · {decision.due}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </aside>
+      </section>
+
+      {children}
+    </main>
+  );
+}
+
+const dashboardShellCss = `
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background: #f7f9f8;
+  color: #18221e;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.batios-dashboard {
+  --accent: #126b5b;
+  --accent-strong: #0a433a;
+  --accent-soft: #e7f2ee;
+  --line: #d7ded8;
+  --muted: #60716a;
+  --panel: #ffffff;
+  --shadow: 0 16px 40px rgb(23 36 31 / 9%);
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px;
+}
+
+.batios-dashboard--pm {
+  --accent: #2f5f98;
+  --accent-strong: #183b63;
+  --accent-soft: #eaf1fa;
+}
+
+.batios-dashboard--qs {
+  --accent: #7a5a12;
+  --accent-strong: #4d3909;
+  --accent-soft: #f8efd7;
+}
+
+.batios-dashboard--admin {
+  --accent: #6f3f87;
+  --accent-strong: #452356;
+  --accent-soft: #f2eaf7;
+}
+
+.batios-dashboard__topbar,
+.batios-dashboard__metrics,
+.batios-dashboard__grid,
+.batios-dashboard__workspace {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.batios-dashboard__topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 18px;
+}
+
+.batios-dashboard__eyebrow {
+  margin: 0 0 7px;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.batios-dashboard h1,
+.batios-dashboard h2 {
+  margin: 0;
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+.batios-dashboard h1 {
+  max-width: 780px;
+  font-size: clamp(2rem, 7vw, 3.8rem);
+}
+
+.batios-dashboard h2 {
+  font-size: 1.15rem;
+}
+
+.batios-dashboard__subtitle {
+  max-width: 720px;
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-weight: 750;
+  line-height: 1.5;
+}
+
+.batios-dashboard__status {
+  display: inline-flex;
+  min-width: 144px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  color: var(--accent-strong);
+  padding: 10px 14px;
+  font-weight: 900;
+}
+
+.batios-dashboard__status span {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+
+.batios-dashboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.batios-dashboard__metric,
+.batios-dashboard__panel,
+.batios-dashboard__workspace-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.batios-dashboard__metric {
+  min-height: 120px;
+  padding: 16px;
+}
+
+.batios-dashboard__metric span,
+.batios-dashboard__metric small {
+  display: block;
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.batios-dashboard__metric strong {
+  display: block;
+  margin: 10px 0;
+  color: var(--accent-strong);
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.batios-dashboard__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.batios-dashboard__panel {
+  padding: 18px;
+}
+
+.batios-dashboard__panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.batios-dashboard__panel-heading > span {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  padding: 7px 10px;
+  font-size: 0.8rem;
+  font-weight: 900;
+}
+
+.batios-dashboard__queue {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.batios-dashboard__queue li {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #f9fbfa;
+  padding: 12px;
+}
+
+.batios-dashboard__queue strong,
+.batios-dashboard__queue span {
+  display: block;
+}
+
+.batios-dashboard__queue span,
+.batios-dashboard__decisions dd,
+.batios-dashboard__workspace-card p {
+  margin-top: 4px;
+  color: var(--muted);
+  font-weight: 750;
+}
+
+.batios-dashboard__queue mark {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  padding: 7px 10px;
+  font-size: 0.74rem;
+  font-weight: 900;
+}
+
+.batios-dashboard__decisions {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.batios-dashboard__decisions div {
+  border-left: 4px solid var(--accent);
+  border-radius: 8px;
+  background: #f9fbfa;
+  padding: 12px;
+}
+
+.batios-dashboard__decisions dt {
+  font-weight: 900;
+}
+
+.batios-dashboard__decisions dd {
+  margin-left: 0;
+}
+
+.batios-dashboard__workspace {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.batios-dashboard__workspace-card {
+  min-height: 140px;
+  padding: 16px;
+}
+
+.batios-dashboard__workspace-card strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+@media (max-width: 900px) {
+  .batios-dashboard__metrics,
+  .batios-dashboard__grid,
+  .batios-dashboard__workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 620px) {
+  .batios-dashboard {
+    padding: 14px;
+  }
+
+  .batios-dashboard__topbar,
+  .batios-dashboard__panel-heading,
+  .batios-dashboard__queue li {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .batios-dashboard__status {
+    width: 100%;
+  }
+}
+`;

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,1 +1,3 @@
 export const designSystemBoundary = 'design-system';
+
+export * from './dashboard-shell.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
 
   apps/admin:
     dependencies:
+      '@batios/design-system':
+        specifier: workspace:*
+        version: link:../../packages/design-system
       next:
         specifier: ^15.0.0
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -80,6 +83,9 @@ importers:
 
   apps/pm-dashboard:
     dependencies:
+      '@batios/design-system':
+        specifier: workspace:*
+        version: link:../../packages/design-system
       next:
         specifier: ^15.0.0
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -92,6 +98,9 @@ importers:
 
   apps/qs-dashboard:
     dependencies:
+      '@batios/design-system':
+        specifier: workspace:*
+        version: link:../../packages/design-system
       next:
         specifier: ^15.0.0
         version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -106,7 +115,11 @@ importers:
 
   packages/api-client: {}
 
-  packages/design-system: {}
+  packages/design-system:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
 
   packages/events-core:
     dependencies:


### PR DESCRIPTION
## Summary
- add a shared design-system DashboardShell for operational dashboard first screens
- replace Admin, PM, and QS dashboard placeholders with dense repeated-work views
- wire dashboard apps to @batios/design-system through workspace dependencies

## Verification
- corepack pnpm --filter @batios/design-system build
- corepack pnpm --filter @batios/design-system lint
- corepack pnpm --filter @batios/design-system typecheck
- corepack pnpm --filter @batios/admin typecheck
- corepack pnpm --filter @batios/pm-dashboard typecheck
- corepack pnpm --filter @batios/qs-dashboard typecheck
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm format:check
- corepack pnpm compliance:scan
- corepack pnpm qa:harness

Local previews:
- Admin: http://localhost:3004
- PM: http://localhost:3005
- QS: http://localhost:3006

Closes #6