### PR TITLE
Build IPC Autopilot orchestration shell

### DIFF
--- a/packages/ipc-autopilot/package.json
+++ b/packages/ipc-autopilot/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "dependencies": {
+    "@batios/agent-gateway": "workspace:*"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ipc-autopilot/src/index.test.ts
+++ b/packages/ipc-autopilot/src/index.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentGateway, AgentGatewayRequest } from '@batios/agent-gateway';
+
+import { assessIpcWorkItem, createIpcAutopilot, type IpcAssessmentWorkItem } from './index.js';
+
+const requestedAt = new Date('2026-04-27T12:00:00.000Z');
+const completedAt = new Date('2026-04-27T12:00:02.000Z');
+
+function baseWorkItem(overrides: Partial<IpcAssessmentWorkItem> = {}): IpcAssessmentWorkItem {
+  return {
+    workItemId: 'ipc-work-001',
+    organisationId: '33333333-3333-4333-8333-333333333333',
+    projectId: '22222222-2222-4222-8222-222222222222',
+    contractReference: 'BAT-ROAD-2026-001',
+    paymentCertificateReference: 'IPC-004',
+    contractItem: 'Drainage culvert concrete works',
+    claimedAmount: 125000,
+    currency: 'GHS',
+    evidenceArtifactIds: ['artifact-measurement-sheet', 'artifact-site-photo'],
+    submittedByUserId: '55555555-5555-4555-8555-555555555555',
+    submittedAt: new Date('2026-04-27T09:30:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('ipc autopilot orchestration', () => {
+  it('routes IPC assessments through the agent gateway with audit metadata', async () => {
+    const gatewayRequests: AgentGatewayRequest[] = [];
+    const gateway: AgentGateway = {
+      async complete(request) {
+        gatewayRequests.push(request);
+        return {
+          requestId: request.metadata.requestId,
+          provider: request.provider,
+          model: request.model,
+          content: JSON.stringify({
+            recommendation: 'needs-review',
+            riskLevel: 'medium',
+            summary: 'Evidence supports the claim, but measurements need QS confirmation.',
+            requiredActions: ['Confirm measured quantities before certification'],
+          }),
+          completedAt,
+        };
+      },
+    };
+
+    const autopilot = createIpcAutopilot({
+      agentGateway: gateway,
+      provider: 'local',
+      model: 'batios-ipc-risk-v1',
+    });
+
+    const result = await autopilot.assess({
+      requestId: 'req-ipc-001',
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      requestedAt,
+      traceId: 'trace-ipc-001',
+      workItem: baseWorkItem(),
+    });
+
+    expect(gatewayRequests).toHaveLength(1);
+    expect(gatewayRequests[0]).toMatchObject({
+      provider: 'local',
+      model: 'batios-ipc-risk-v1',
+      temperature: 0.1,
+      responseFormat: 'json',
+      metadata: {
+        requestId: 'req-ipc-001',
+        organisationId: '33333333-3333-4333-8333-333333333333',
+        projectId: '22222222-2222-4222-8222-222222222222',
+        actorUserId: '44444444-4444-4444-8444-444444444444',
+        purpose: 'payment-risk-review',
+        custodyScope: 'project-joint-custody',
+        policyTags: ['ipc-autopilot', 'payment-certificate', 'no-training'],
+        retention: 'audit-log',
+        requestedAt,
+        traceId: 'trace-ipc-001',
+      },
+    });
+    expect(gatewayRequests[0]?.messages).toHaveLength(2);
+    expect(gatewayRequests[0]?.messages[1]?.content).toContain('artifact-measurement-sheet');
+    expect(result).toEqual({
+      assessmentId: 'ipc:ipc-work-001:req-ipc-001',
+      gatewayRequestId: 'req-ipc-001',
+      workItemId: 'ipc-work-001',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      recommendation: 'needs-review',
+      riskLevel: 'medium',
+      summary: 'Evidence supports the claim, but measurements need QS confirmation.',
+      requiredActions: ['Confirm measured quantities before certification'],
+      sourceArtifactIds: ['artifact-measurement-sheet', 'artifact-site-photo'],
+      assessedAt: completedAt,
+    });
+  });
+
+  it('rejects work items without evidence artifacts before calling the gateway', async () => {
+    const gatewayRequests: AgentGatewayRequest[] = [];
+    const gateway: AgentGateway = {
+      async complete(request) {
+        gatewayRequests.push(request);
+        throw new Error('gateway should not be called');
+      },
+    };
+
+    await expect(
+      assessIpcWorkItem(
+        {
+          agentGateway: gateway,
+          provider: 'local',
+          model: 'batios-ipc-risk-v1',
+        },
+        {
+          requestId: 'req-ipc-002',
+          actorUserId: '44444444-4444-4444-8444-444444444444',
+          workItem: baseWorkItem({ evidenceArtifactIds: [] }),
+        },
+      ),
+    ).rejects.toThrow('workItem.evidenceArtifactIds must contain at least one artifact');
+
+    expect(gatewayRequests).toHaveLength(0);
+  });
+
+  it('fails closed when the gateway returns an invalid assessment payload', async () => {
+    const gateway: AgentGateway = {
+      async complete(request) {
+        return {
+          requestId: request.metadata.requestId,
+          provider: request.provider,
+          model: request.model,
+          content: JSON.stringify({ recommendation: 'approve', summary: '' }),
+          completedAt,
+        };
+      },
+    };
+
+    await expect(
+      assessIpcWorkItem(
+        {
+          agentGateway: gateway,
+          provider: 'local',
+          model: 'batios-ipc-risk-v1',
+        },
+        {
+          requestId: 'req-ipc-003',
+          actorUserId: '44444444-4444-4444-8444-444444444444',
+          requestedAt,
+          workItem: baseWorkItem(),
+        },
+      ),
+    ).rejects.toThrow('IPC_AUTOPILOT_INVALID_GATEWAY_RESPONSE');
+  });
+});

--- a/packages/ipc-autopilot/src/index.ts
+++ b/packages/ipc-autopilot/src/index.ts
@@ -1,1 +1,232 @@
+import type {
+  AgentGateway,
+  AgentGatewayProvider,
+  AgentGatewayRequest,
+  AgentGatewayResponse,
+} from '@batios/agent-gateway';
+
 export const ipcAutopilotBoundary = 'ipc-autopilot';
+
+export type IpcAssessmentRecommendation = 'approve' | 'needs-review' | 'reject';
+
+export type IpcAssessmentRiskLevel = 'low' | 'medium' | 'high';
+
+export interface IpcAssessmentWorkItem {
+  workItemId: string;
+  organisationId: string;
+  projectId: string;
+  contractReference: string;
+  paymentCertificateReference: string;
+  contractItem: string;
+  claimedAmount: number;
+  currency: string;
+  evidenceArtifactIds: readonly string[];
+  submittedByUserId: string;
+  submittedAt: Date;
+}
+
+export interface IpcAutopilotInput {
+  requestId: string;
+  actorUserId: string;
+  workItem: IpcAssessmentWorkItem;
+  requestedAt?: Date;
+  traceId?: string;
+}
+
+export interface IpcAutopilotOptions {
+  agentGateway: AgentGateway;
+  provider: AgentGatewayProvider;
+  model: string;
+  now?: () => Date;
+}
+
+export interface IpcAssessmentResult {
+  assessmentId: string;
+  gatewayRequestId: string;
+  workItemId: string;
+  organisationId: string;
+  projectId: string;
+  recommendation: IpcAssessmentRecommendation;
+  riskLevel: IpcAssessmentRiskLevel;
+  summary: string;
+  requiredActions: readonly string[];
+  sourceArtifactIds: readonly string[];
+  assessedAt: Date;
+}
+
+interface GatewayAssessmentPayload {
+  recommendation: IpcAssessmentRecommendation;
+  riskLevel: IpcAssessmentRiskLevel;
+  summary: string;
+  requiredActions: readonly string[];
+}
+
+export interface IpcAutopilot {
+  assess(input: IpcAutopilotInput): Promise<IpcAssessmentResult>;
+}
+
+export function createIpcAutopilot(options: IpcAutopilotOptions): IpcAutopilot {
+  return {
+    assess(input) {
+      return assessIpcWorkItem(options, input);
+    },
+  };
+}
+
+export async function assessIpcWorkItem(
+  options: IpcAutopilotOptions,
+  input: IpcAutopilotInput,
+): Promise<IpcAssessmentResult> {
+  assertWorkItemReady(input.workItem);
+
+  const requestedAt = input.requestedAt ?? options.now?.() ?? new Date();
+  const response = await options.agentGateway.complete(
+    toIpcAssessmentRequest(options, input, requestedAt),
+  );
+  const payload = parseGatewayAssessment(response);
+
+  return {
+    assessmentId: `ipc:${input.workItem.workItemId}:${input.requestId}`,
+    gatewayRequestId: response.requestId,
+    workItemId: input.workItem.workItemId,
+    organisationId: input.workItem.organisationId,
+    projectId: input.workItem.projectId,
+    recommendation: payload.recommendation,
+    riskLevel: payload.riskLevel,
+    summary: payload.summary,
+    requiredActions: payload.requiredActions,
+    sourceArtifactIds: input.workItem.evidenceArtifactIds,
+    assessedAt: response.completedAt,
+  };
+}
+
+export function toIpcAssessmentRequest(
+  options: Pick<IpcAutopilotOptions, 'provider' | 'model'>,
+  input: IpcAutopilotInput,
+  requestedAt: Date,
+): AgentGatewayRequest {
+  const metadata: AgentGatewayRequest['metadata'] = {
+    requestId: input.requestId,
+    organisationId: input.workItem.organisationId,
+    projectId: input.workItem.projectId,
+    actorUserId: input.actorUserId,
+    purpose: 'payment-risk-review',
+    custodyScope: 'project-joint-custody',
+    policyTags: ['ipc-autopilot', 'payment-certificate', 'no-training'],
+    retention: 'audit-log',
+    requestedAt,
+  };
+
+  if (input.traceId !== undefined) {
+    metadata.traceId = input.traceId;
+  }
+
+  return {
+    provider: options.provider,
+    model: options.model,
+    messages: [
+      {
+        role: 'system',
+        content:
+          'Assess interim payment certificate risk for an African public works contract. Return strict JSON only.',
+      },
+      {
+        role: 'user',
+        content: JSON.stringify(toPromptPayload(input.workItem)),
+      },
+    ],
+    metadata,
+    temperature: 0.1,
+    responseFormat: 'json',
+  };
+}
+
+function toPromptPayload(workItem: IpcAssessmentWorkItem): Record<string, unknown> {
+  return {
+    task: 'ipc-assessment',
+    expectedResponse: {
+      recommendation: 'approve | needs-review | reject',
+      riskLevel: 'low | medium | high',
+      summary: 'short audit-ready rationale',
+      requiredActions: ['action required before approval'],
+    },
+    workItem: {
+      workItemId: workItem.workItemId,
+      projectId: workItem.projectId,
+      contractReference: workItem.contractReference,
+      paymentCertificateReference: workItem.paymentCertificateReference,
+      contractItem: workItem.contractItem,
+      claimedAmount: workItem.claimedAmount,
+      currency: workItem.currency,
+      evidenceArtifactIds: workItem.evidenceArtifactIds,
+      submittedByUserId: workItem.submittedByUserId,
+      submittedAt: workItem.submittedAt.toISOString(),
+    },
+  };
+}
+
+function parseGatewayAssessment(response: AgentGatewayResponse): GatewayAssessmentPayload {
+  try {
+    const parsed: unknown = JSON.parse(response.content);
+
+    if (!isGatewayAssessmentPayload(parsed)) {
+      throw new Error('response shape is invalid');
+    }
+
+    return parsed;
+  } catch (error) {
+    throw new Error('IPC_AUTOPILOT_INVALID_GATEWAY_RESPONSE', { cause: error });
+  }
+}
+
+function isGatewayAssessmentPayload(value: unknown): value is GatewayAssessmentPayload {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    isRecommendation(value.recommendation) &&
+    isRiskLevel(value.riskLevel) &&
+    typeof value.summary === 'string' &&
+    value.summary.trim().length > 0 &&
+    Array.isArray(value.requiredActions) &&
+    value.requiredActions.every((action) => typeof action === 'string' && action.trim().length > 0)
+  );
+}
+
+function isRecommendation(value: unknown): value is IpcAssessmentRecommendation {
+  return value === 'approve' || value === 'needs-review' || value === 'reject';
+}
+
+function isRiskLevel(value: unknown): value is IpcAssessmentRiskLevel {
+  return value === 'low' || value === 'medium' || value === 'high';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function assertWorkItemReady(workItem: IpcAssessmentWorkItem): void {
+  assertNonEmpty(workItem.workItemId, 'workItem.workItemId');
+  assertNonEmpty(workItem.organisationId, 'workItem.organisationId');
+  assertNonEmpty(workItem.projectId, 'workItem.projectId');
+  assertNonEmpty(workItem.contractReference, 'workItem.contractReference');
+  assertNonEmpty(workItem.paymentCertificateReference, 'workItem.paymentCertificateReference');
+  assertNonEmpty(workItem.contractItem, 'workItem.contractItem');
+  assertNonEmpty(workItem.currency, 'workItem.currency');
+  assertNonEmpty(workItem.submittedByUserId, 'workItem.submittedByUserId');
+
+  if (!Number.isFinite(workItem.claimedAmount) || workItem.claimedAmount <= 0) {
+    throw new Error('workItem.claimedAmount must be greater than zero');
+  }
+
+  if (workItem.evidenceArtifactIds.length === 0) {
+    throw new Error('workItem.evidenceArtifactIds must contain at least one artifact');
+  }
+}
+
+function assertNonEmpty(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,11 @@ importers:
         specifier: ^0.27.5
         version: 0.27.6
 
-  packages/ipc-autopilot: {}
+  packages/ipc-autopilot:
+    dependencies:
+      '@batios/agent-gateway':
+        specifier: workspace:*
+        version: link:../agent-gateway
 
   packages/platform-core:
     dependencies:


### PR DESCRIPTION
## Summary
- add a typed IPC Autopilot public API and orchestration entrypoint
- route assessments through the Agent Gateway with audit metadata and JSON response format
- add unit tests for gateway routing, validation, and fail-closed response parsing

## Verification
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan

Closes #7