### PR TITLE
Add staging deployment contract

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,16 @@
+# Copy to the staging provider secret store. Do not commit real values.
+
+BATIOS_ENVIRONMENT=staging
+DATABASE_URL=postgres://batios_staging:replace-me@staging-db.example.com:5432/batios_staging
+BATIOS_ORGANISATION_ID=00000000-0000-0000-0000-000000000000
+BATIOS_SESSION_SECRET=replace-with-32-byte-random-secret
+
+# Public app URLs used by smoke checks and cross-app navigation.
+BATIOS_FIELD_PWA_URL=https://field.staging.batios.example
+BATIOS_ADMIN_URL=https://admin.staging.batios.example
+BATIOS_PM_DASHBOARD_URL=https://pm.staging.batios.example
+BATIOS_QS_DASHBOARD_URL=https://qs.staging.batios.example
+
+# Optional until a hosted provider is wired behind packages/agent-gateway.
+BATIOS_AGENT_GATEWAY_PROVIDER=local
+BATIOS_AGENT_GATEWAY_MODEL=batios-local-staging

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ coverage/
 .env
 .env.*
 !.env.example
+!.env.staging.example
 *.tsbuildinfo

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,74 @@
+# Staging Deployment Contract
+
+This contract defines the first reproducible staging target for BatiOS. Staging
+must run from a clean checkout of `main`, use only values supplied through the
+deployment provider secret store, and pass smoke checks before it is treated as
+ready for end-to-end testing.
+
+## Required Runtime
+
+- Node.js 20.18.x
+- Corepack enabled
+- pnpm 9.12.0
+- PostgreSQL 16.x
+
+## Required Secrets And Environment
+
+Real values belong in the deployment provider secret store. The repository only
+keeps placeholders in `.env.staging.example`.
+
+| Name                            | Owner    | Required | Purpose                                            |
+| ------------------------------- | -------- | -------- | -------------------------------------------------- |
+| `BATIOS_ENVIRONMENT`            | Platform | Yes      | Must be `staging` for staging deployments.         |
+| `DATABASE_URL`                  | Platform | Yes      | PostgreSQL 16 connection string for staging data.  |
+| `BATIOS_ORGANISATION_ID`        | Platform | Yes      | Default organisation context for smoke fixtures.   |
+| `BATIOS_SESSION_SECRET`         | Platform | Yes      | Session/signing secret; minimum 32 random bytes.   |
+| `BATIOS_FIELD_PWA_URL`          | Frontend | Yes      | Public Field PWA staging URL.                      |
+| `BATIOS_ADMIN_URL`              | Frontend | Yes      | Public Admin staging URL.                          |
+| `BATIOS_PM_DASHBOARD_URL`       | Frontend | Yes      | Public PM dashboard staging URL.                   |
+| `BATIOS_QS_DASHBOARD_URL`       | Frontend | Yes      | Public QS dashboard staging URL.                   |
+| `BATIOS_AGENT_GATEWAY_PROVIDER` | Platform | Optional | Provider routed through `packages/agent-gateway`.  |
+| `BATIOS_AGENT_GATEWAY_MODEL`    | Platform | Optional | Model identifier for IPC Autopilot staging checks. |
+
+## Clean Checkout Build
+
+Run these commands from a fresh checkout:
+
+```bash
+corepack enable
+corepack pnpm install --frozen-lockfile
+corepack pnpm build
+corepack pnpm lint
+corepack pnpm typecheck
+corepack pnpm test
+corepack pnpm format:check
+corepack pnpm qa:harness
+corepack pnpm compliance:scan
+```
+
+## Staging Smoke Check
+
+After deployment, export the four public app URLs and run:
+
+```bash
+corepack pnpm staging:smoke
+```
+
+The smoke check performs an HTTP `GET` against:
+
+- Field PWA
+- Admin dashboard
+- PM dashboard
+- QS dashboard
+
+Each endpoint must return a 2xx or 3xx status. The script does not require or
+print secret values.
+
+## Readiness Criteria
+
+Staging is ready for E2E work when:
+
+- The clean checkout build passes.
+- All required environment variables are set in the deployment provider.
+- `corepack pnpm staging:smoke` passes against deployed app URLs.
+- No real secret values are committed to the repository.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,json,md,yaml,yml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json,md,yaml,yml}\"",
     "qa:harness": "node packages/qa-harness/dist/index.js",
-    "compliance:scan": "node compliance-mapper-stub.mjs"
+    "compliance:scan": "node compliance-mapper-stub.mjs",
+    "staging:smoke": "node scripts/staging-smoke-check.mjs"
   },
   "dependencies": {
     "kysely": "^0.27.5"

--- a/scripts/staging-smoke-check.mjs
+++ b/scripts/staging-smoke-check.mjs
@@ -1,0 +1,42 @@
+const requiredTargets = [
+  ['BATIOS_FIELD_PWA_URL', 'Field PWA'],
+  ['BATIOS_ADMIN_URL', 'Admin dashboard'],
+  ['BATIOS_PM_DASHBOARD_URL', 'PM dashboard'],
+  ['BATIOS_QS_DASHBOARD_URL', 'QS dashboard'],
+];
+
+const missing = requiredTargets
+  .filter(([envName]) => process.env[envName] === undefined || process.env[envName]?.trim() === '')
+  .map(([envName]) => envName);
+
+if (missing.length > 0) {
+  console.error(`Missing required staging smoke check env vars: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+const failures = [];
+
+for (const [envName, label] of requiredTargets) {
+  const url = process.env[envName];
+
+  try {
+    const response = await fetch(url, { redirect: 'manual' });
+
+    if (response.status < 200 || response.status >= 400) {
+      failures.push(`${label} returned HTTP ${response.status}`);
+      continue;
+    }
+
+    console.log(`${label}: ${response.status}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'request failed';
+    failures.push(`${label} failed: ${message}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exit(1);
+}
+
+console.log('Staging smoke check passed.');


### PR DESCRIPTION
## Summary
- document the staging runtime, clean checkout build path, and readiness criteria
- add a safe .env.staging.example template while keeping real env files ignored
- add a staging:smoke script covering Field PWA, Admin, PM, and QS public URLs

## Verification
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm build
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan
- corepack pnpm staging:smoke against local Field/Admin/PM/QS preview URLs

Closes #17