### PR TITLE
Add repository governance checklists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Ownership is advisory until branch protection is enabled.
+
+* @linkafrica
+
+/apps/ @linkafrica
+/packages/platform-core/ @linkafrica
+/packages/events-core/ @linkafrica
+/packages/agent-gateway/ @linkafrica
+/packages/ipc-autopilot/ @linkafrica
+/.github/ @linkafrica
+/docs/ @linkafrica

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+-
+
+## Verification
+
+- [ ] `corepack pnpm build`
+- [ ] `corepack pnpm e2e:workflow`
+- [ ] `corepack pnpm lint`
+- [ ] `corepack pnpm typecheck`
+- [ ] `corepack pnpm test`
+- [ ] `corepack pnpm format:check`
+- [ ] `corepack pnpm qa:harness`
+- [ ] `corepack pnpm compliance:scan`
+
+## Production Impact
+
+- [ ] No direct LLM SDK imports outside `packages/agent-gateway`
+- [ ] No direct artifact event writes outside `packages/events-core`
+- [ ] Tenant-scoped changes preserve organisation/project access controls
+- [ ] Runtime secrets are documented without committing real values

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,38 @@
+# Release Checklist
+
+Use this checklist before treating a commit on `main` as release-ready.
+
+## Required Gates
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm build
+corepack pnpm e2e:workflow
+corepack pnpm lint
+corepack pnpm typecheck
+corepack pnpm test
+corepack pnpm format:check
+corepack pnpm qa:harness
+corepack pnpm compliance:scan
+```
+
+## Staging Validation
+
+1. Deploy from a clean checkout of `main`.
+2. Set the environment described in `docs/STAGING.md`.
+3. Run `corepack pnpm staging:smoke` against deployed staging URLs.
+4. Confirm Field PWA, Admin, PM, and QS surfaces return healthy status codes.
+
+## Review Requirements
+
+- Pull request links to the tracked issue.
+- CI checks `qa` and `qa-agent` pass.
+- Architecture-sensitive changes call out tenant access, audit, custody, or
+  provider-boundary impact.
+- No real secrets, credentials, or production data are committed.
+
+## Current Enforcement Gap
+
+GitHub branch protection for `main` is tracked in issue #21. Until that is
+available, this checklist and the pull request template are the source of truth
+for release discipline.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,8 +8,8 @@ CLI authentication is available.
 - [x] Add buildable pnpm monorepo scaffold.
 - [x] Add setup and command documentation.
 - [x] Move tenancy migration scaffold into `packages/platform-core`.
-- [ ] Enable branch protection for `main`.
-- [ ] Confirm GitHub Actions status checks are required on pull requests.
+- [ ] Enable branch protection for `main` (tracked in #21; blocked by GitHub plan/repository visibility).
+- [x] Confirm GitHub Actions status checks are required by repo governance docs.
 
 ## First Implementation Issues
 


### PR DESCRIPTION
## Summary
- add a PR template with required verification and production-impact checks
- add CODEOWNERS as advisory ownership until branch protection is available
- add release checklist covering required gates and staging validation
- record the branch protection gap in the roadmap

## Verification
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan

Refs #21