### PR TITLE
Add app health endpoints

### DIFF
--- a/apps/admin/app/healthz/route.ts
+++ b/apps/admin/app/healthz/route.ts
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return Response.json({
+    service: 'admin',
+    status: 'ok',
+    checkedAt: new Date().toISOString(),
+  });
+}

--- a/apps/field-pwa/app/healthz/route.ts
+++ b/apps/field-pwa/app/healthz/route.ts
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return Response.json({
+    service: 'field-pwa',
+    status: 'ok',
+    checkedAt: new Date().toISOString(),
+  });
+}

--- a/apps/pm-dashboard/app/healthz/route.ts
+++ b/apps/pm-dashboard/app/healthz/route.ts
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return Response.json({
+    service: 'pm-dashboard',
+    status: 'ok',
+    checkedAt: new Date().toISOString(),
+  });
+}

--- a/apps/qs-dashboard/app/healthz/route.ts
+++ b/apps/qs-dashboard/app/healthz/route.ts
@@ -1,0 +1,9 @@
+export const dynamic = 'force-dynamic';
+
+export function GET(): Response {
+  return Response.json({
+    service: 'qs-dashboard',
+    status: 'ok',
+    checkedAt: new Date().toISOString(),
+  });
+}

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -54,15 +54,16 @@ After deployment, export the four public app URLs and run:
 corepack pnpm staging:smoke
 ```
 
-The smoke check performs an HTTP `GET` against:
+The smoke check performs an HTTP `GET` against each app's `/healthz` endpoint:
 
 - Field PWA
 - Admin dashboard
 - PM dashboard
 - QS dashboard
 
-Each endpoint must return a 2xx or 3xx status. The script does not require or
-print secret values.
+Each endpoint must return a 2xx or 3xx status and a JSON payload with the
+expected service name, `status: "ok"`, and a valid `checkedAt` timestamp. The
+script does not require or print secret values.
 
 ## Readiness Criteria
 

--- a/scripts/staging-smoke-check.mjs
+++ b/scripts/staging-smoke-check.mjs
@@ -1,8 +1,8 @@
 const requiredTargets = [
-  ['BATIOS_FIELD_PWA_URL', 'Field PWA'],
-  ['BATIOS_ADMIN_URL', 'Admin dashboard'],
-  ['BATIOS_PM_DASHBOARD_URL', 'PM dashboard'],
-  ['BATIOS_QS_DASHBOARD_URL', 'QS dashboard'],
+  ['BATIOS_FIELD_PWA_URL', 'Field PWA', 'field-pwa'],
+  ['BATIOS_ADMIN_URL', 'Admin dashboard', 'admin'],
+  ['BATIOS_PM_DASHBOARD_URL', 'PM dashboard', 'pm-dashboard'],
+  ['BATIOS_QS_DASHBOARD_URL', 'QS dashboard', 'qs-dashboard'],
 ];
 
 const missing = requiredTargets
@@ -16,14 +16,26 @@ if (missing.length > 0) {
 
 const failures = [];
 
-for (const [envName, label] of requiredTargets) {
-  const url = process.env[envName];
+for (const [envName, label, service] of requiredTargets) {
+  const url = toHealthUrl(process.env[envName]);
 
   try {
     const response = await fetch(url, { redirect: 'manual' });
 
     if (response.status < 200 || response.status >= 400) {
       failures.push(`${label} returned HTTP ${response.status}`);
+      continue;
+    }
+
+    const payload = await response.json();
+
+    if (payload.service !== service || payload.status !== 'ok') {
+      failures.push(`${label} returned invalid health payload`);
+      continue;
+    }
+
+    if (typeof payload.checkedAt !== 'string' || Number.isNaN(Date.parse(payload.checkedAt))) {
+      failures.push(`${label} returned invalid health timestamp`);
       continue;
     }
 
@@ -40,3 +52,7 @@ if (failures.length > 0) {
 }
 
 console.log('Staging smoke check passed.');
+
+function toHealthUrl(baseUrl) {
+  return new URL('/healthz', baseUrl).toString();
+}


### PR DESCRIPTION
## Summary
- add /healthz route handlers for Field PWA, Admin, PM dashboard, and QS dashboard
- return service, status, and checkedAt JSON for each deployable app
- update staging smoke checks to validate /healthz payloads instead of UI pages
- document the health-based smoke contract

## Verification
- corepack pnpm build
- corepack pnpm e2e:workflow
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan
- corepack pnpm staging:smoke against local app URLs

Closes #23