### PR TITLE
Add Fly.io deployment scaffold

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.next
+**/.next
+dist
+**/dist
+node_modules
+**/node_modules
+coverage
+.env
+.env.*
+!.env.example
+!.env.staging.example
+*.tsbuildinfo
+**/*.tsbuildinfo

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/field-pwa/next.config.mjs
+++ b/apps/field-pwa/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/pm-dashboard/next.config.mjs
+++ b/apps/pm-dashboard/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/qs-dashboard/next.config.mjs
+++ b/apps/qs-dashboard/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/deploy/fly/Dockerfile.next
+++ b/deploy/fly/Dockerfile.next
@@ -1,0 +1,34 @@
+FROM node:20.18.0-bookworm-slim AS base
+WORKDIR /app
+RUN npm install --global pnpm@9.12.0
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+RUN pnpm install --frozen-lockfile
+
+FROM deps AS build
+ARG APP_DIR
+ARG PACKAGE_NAME
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm --filter @batios/design-system clean && pnpm --filter @batios/design-system build
+RUN pnpm --filter ${PACKAGE_NAME} build
+
+FROM node:20.18.0-bookworm-slim AS runner
+ARG APP_DIR
+ENV APP_DIR=${APP_DIR}
+ENV HOSTNAME=0.0.0.0
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=8080
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+
+COPY --from=build --chown=nextjs:nodejs /app/apps/${APP_DIR}/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/apps/${APP_DIR}/.next/static ./apps/${APP_DIR}/.next/static
+
+USER nextjs
+EXPOSE 8080
+CMD ["sh", "-c", "node apps/${APP_DIR}/server.js"]

--- a/deploy/fly/admin.fly.toml
+++ b/deploy/fly/admin.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-admin-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "admin"
+    PACKAGE_NAME = "@batios/admin"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/field-pwa.fly.toml
+++ b/deploy/fly/field-pwa.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-field-pwa-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "field-pwa"
+    PACKAGE_NAME = "@batios/field-pwa"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/pm-dashboard.fly.toml
+++ b/deploy/fly/pm-dashboard.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-pm-dashboard-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "pm-dashboard"
+    PACKAGE_NAME = "@batios/pm-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/qs-dashboard.fly.toml
+++ b/deploy/fly/qs-dashboard.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-qs-dashboard-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "qs-dashboard"
+    PACKAGE_NAME = "@batios/qs-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -1,0 +1,87 @@
+# Fly.io Deployment
+
+BatiOS deploys to Fly.io as four Next.js apps plus one PostgreSQL 16 database.
+Each app uses the shared Dockerfile at `deploy/fly/Dockerfile.next` and its own
+Fly config.
+
+## Apps
+
+| Surface      | Fly config                         | Staging app name              |
+| ------------ | ---------------------------------- | ----------------------------- |
+| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `batios-field-pwa-staging`    |
+| Admin        | `deploy/fly/admin.fly.toml`        | `batios-admin-staging`        |
+| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `batios-pm-dashboard-staging` |
+| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `batios-qs-dashboard-staging` |
+
+## One-Time Setup
+
+Install and authenticate the Fly CLI:
+
+```bash
+fly auth login
+```
+
+Create the staging Postgres app:
+
+```bash
+fly postgres create \
+  --name batios-postgres-staging \
+  --region jnb \
+  --initial-cluster-size 1 \
+  --vm-size shared-cpu-1x \
+  --volume-size 10
+```
+
+Enable managed backups before production cutover. Some Fly CLI versions require
+Tigris terms acceptance before `--enable-backups` works during `postgres create`;
+use the Fly dashboard, a newer CLI, or Managed Postgres if the CLI cannot enable
+backups non-interactively.
+
+Create the four staging apps without deploying:
+
+```bash
+fly apps create batios-field-pwa-staging
+fly apps create batios-admin-staging
+fly apps create batios-pm-dashboard-staging
+fly apps create batios-qs-dashboard-staging
+```
+
+Set required runtime secrets on each app. Use the generated Fly Postgres
+connection string for `DATABASE_URL`.
+
+```bash
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  BATIOS_ORGANISATION_ID="00000000-0000-0000-0000-000000000000" \
+  BATIOS_SESSION_SECRET="replace-with-32-byte-random-secret" \
+  --app batios-field-pwa-staging
+```
+
+Repeat `fly secrets set` for the Admin, PM, and QS apps.
+
+## Deploy
+
+Deploy each app from the repository root:
+
+```bash
+fly deploy --config deploy/fly/field-pwa.fly.toml
+fly deploy --config deploy/fly/admin.fly.toml
+fly deploy --config deploy/fly/pm-dashboard.fly.toml
+fly deploy --config deploy/fly/qs-dashboard.fly.toml
+```
+
+## Verify
+
+Export staging URLs and run the smoke check:
+
+```bash
+export BATIOS_FIELD_PWA_URL="https://batios-field-pwa-staging.fly.dev"
+export BATIOS_ADMIN_URL="https://batios-admin-staging.fly.dev"
+export BATIOS_PM_DASHBOARD_URL="https://batios-pm-dashboard-staging.fly.dev"
+export BATIOS_QS_DASHBOARD_URL="https://batios-qs-dashboard-staging.fly.dev"
+
+corepack pnpm staging:smoke
+```
+
+The smoke check calls each app's `/healthz` endpoint and validates the JSON
+health contract.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -48,6 +48,8 @@ corepack pnpm compliance:scan
 
 ## Staging Smoke Check
 
+Fly.io deployment steps live in `docs/FLY.md`.
+
 After deployment, export the four public app URLs and run:
 
 ```bash


### PR DESCRIPTION
## Summary
- enable standalone Next output for all deployable apps
- add a shared Fly Dockerfile for monorepo Next app deployments
- add per-app Fly staging configs for Field PWA, Admin, PM, and QS
- document Fly Postgres creation, app creation, secrets, deploy commands, and smoke checks

## Live staging URLs
- Field PWA: https://batios-field-pwa-staging.fly.dev
- Admin: https://batios-admin-staging.fly.dev
- PM dashboard: https://batios-pm-dashboard-staging.fly.dev
- QS dashboard: https://batios-qs-dashboard-staging.fly.dev

## Verification
- corepack pnpm build
- verified standalone server paths exist for all four apps
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm e2e:workflow
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan
- flyctl deploy --config deploy/fly/field-pwa.fly.toml --remote-only
- flyctl deploy --config deploy/fly/admin.fly.toml --remote-only --no-cache
- flyctl deploy --config deploy/fly/pm-dashboard.fly.toml --remote-only
- flyctl deploy --config deploy/fly/qs-dashboard.fly.toml --remote-only
- corepack pnpm staging:smoke: Field PWA 200, Admin dashboard 200, PM dashboard 200, QS dashboard 200

## Production note
Fly Postgres backups are not enabled yet because the current Fly CLI requires Tigris terms acceptance for backup setup but does not support the needed non-interactive flag on postgres create. Enable backups via Fly dashboard, an updated CLI, or Managed Postgres before production cutover.

Closes #25