### PR TITLE
Add Fly.io production cutover hardening

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,16 @@
+# Copy to the production provider secret store. Do not commit real values.
+
+BATIOS_ENVIRONMENT=production
+DATABASE_URL=postgres://batios_production:replace-me@production-db.example.com:5432/batios_production
+BATIOS_ORGANISATION_ID=00000000-0000-0000-0000-000000000000
+BATIOS_SESSION_SECRET=replace-with-32-byte-random-secret
+
+# Public app URLs used by smoke checks and cross-app navigation.
+BATIOS_FIELD_PWA_URL=https://field.batios.example
+BATIOS_ADMIN_URL=https://admin.batios.example
+BATIOS_PM_DASHBOARD_URL=https://pm.batios.example
+BATIOS_QS_DASHBOARD_URL=https://qs.batios.example
+
+# Optional until a hosted provider is wired behind packages/agent-gateway.
+BATIOS_AGENT_GATEWAY_PROVIDER=local
+BATIOS_AGENT_GATEWAY_MODEL=batios-local-production

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ coverage/
 .env.*
 !.env.example
 !.env.staging.example
+!.env.production.example
 *.tsbuildinfo

--- a/deploy/fly/admin.production.fly.toml
+++ b/deploy/fly/admin.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-admin"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "admin"
+    PACKAGE_NAME = "@batios/admin"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/field-pwa.production.fly.toml
+++ b/deploy/fly/field-pwa.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-field-pwa"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "field-pwa"
+    PACKAGE_NAME = "@batios/field-pwa"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/pm-dashboard.production.fly.toml
+++ b/deploy/fly/pm-dashboard.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-pm-dashboard"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "pm-dashboard"
+    PACKAGE_NAME = "@batios/pm-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/qs-dashboard.production.fly.toml
+++ b/deploy/fly/qs-dashboard.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-qs-dashboard"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "qs-dashboard"
+    PACKAGE_NAME = "@batios/qs-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -6,12 +6,14 @@ Fly config.
 
 ## Apps
 
-| Surface      | Fly config                         | Staging app name              |
-| ------------ | ---------------------------------- | ----------------------------- |
-| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `batios-field-pwa-staging`    |
-| Admin        | `deploy/fly/admin.fly.toml`        | `batios-admin-staging`        |
-| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `batios-pm-dashboard-staging` |
-| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `batios-qs-dashboard-staging` |
+| Surface      | Staging config                     | Production config                             |
+| ------------ | ---------------------------------- | --------------------------------------------- |
+| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `deploy/fly/field-pwa.production.fly.toml`    |
+| Admin        | `deploy/fly/admin.fly.toml`        | `deploy/fly/admin.production.fly.toml`        |
+| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `deploy/fly/pm-dashboard.production.fly.toml` |
+| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `deploy/fly/qs-dashboard.production.fly.toml` |
+
+Production cutover requirements live in `docs/PRODUCTION.md`.
 
 ## One-Time Setup
 

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,172 @@
+# Production Cutover Checklist
+
+This checklist promotes the Fly.io staging deployment into a production-ready
+operating model. Do not route real users or critical data to production until
+every required item is complete.
+
+## Production Surfaces
+
+| Surface      | Fly config                                    | Production app name   | Example domain         |
+| ------------ | --------------------------------------------- | --------------------- | ---------------------- |
+| Field PWA    | `deploy/fly/field-pwa.production.fly.toml`    | `batios-field-pwa`    | `field.batios.example` |
+| Admin        | `deploy/fly/admin.production.fly.toml`        | `batios-admin`        | `admin.batios.example` |
+| PM dashboard | `deploy/fly/pm-dashboard.production.fly.toml` | `batios-pm-dashboard` | `pm.batios.example`    |
+| QS dashboard | `deploy/fly/qs-dashboard.production.fly.toml` | `batios-qs-dashboard` | `qs.batios.example`    |
+
+Production configs intentionally set `BATIOS_ENVIRONMENT=production`,
+`auto_stop_machines="off"`, and `min_machines_running=1` so production traffic
+does not wait for cold starts. Revisit machine count, memory, and CPU after the
+first real load profile is measured.
+
+## Database Gate
+
+Production must use a verified backup and restore path before cutover.
+
+Recommended path:
+
+1. Provision Fly Managed Postgres for production.
+2. Store the Managed Postgres connection string as `DATABASE_URL` on each
+   production app.
+3. Verify automated backups are enabled in Fly.
+4. Perform a restore rehearsal into a separate database or cluster.
+5. Record the restore timestamp, operator, and verification result in the
+   release notes.
+
+Fallback path for unmanaged Fly Postgres:
+
+1. Enable backups with `fly postgres backup enable --app <postgres-app>`.
+2. Create a manual backup with `fly postgres backup create --app <postgres-app>`.
+3. List backups with `fly postgres backup list --app <postgres-app>`.
+4. Restore into a new cluster with `fly postgres backup restore`.
+5. Attach a non-production app to the restored database and run smoke checks.
+
+If backup enablement is blocked by CLI or account terms, stop the cutover and
+resolve it in the Fly dashboard or with Fly support. Do not accept volume
+snapshots alone as the only production recovery path.
+
+## Secret Checklist
+
+Set these values through Fly secrets or another approved provider secret store.
+Never commit real values.
+
+| Name                            | Required | Production rule                                       |
+| ------------------------------- | -------- | ----------------------------------------------------- |
+| `DATABASE_URL`                  | Yes      | Production database only; no staging credentials.     |
+| `BATIOS_ORGANISATION_ID`        | Yes      | Real default organisation or controlled bootstrap ID. |
+| `BATIOS_SESSION_SECRET`         | Yes      | Unique 32-byte minimum random value.                  |
+| `BATIOS_AGENT_GATEWAY_PROVIDER` | Optional | Real provider only after audit path is approved.      |
+| `BATIOS_AGENT_GATEWAY_MODEL`    | Optional | Production-approved model identifier.                 |
+
+Use `.env.production.example` only as the shape of required configuration.
+
+## App Provisioning
+
+Create production apps once:
+
+```bash
+fly apps create batios-field-pwa
+fly apps create batios-admin
+fly apps create batios-pm-dashboard
+fly apps create batios-qs-dashboard
+```
+
+Set secrets on each app:
+
+```bash
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  BATIOS_ORGANISATION_ID="00000000-0000-0000-0000-000000000000" \
+  BATIOS_SESSION_SECRET="replace-with-production-secret" \
+  BATIOS_AGENT_GATEWAY_PROVIDER="local" \
+  BATIOS_AGENT_GATEWAY_MODEL="batios-local-production" \
+  --app batios-field-pwa
+```
+
+Repeat for Admin, PM dashboard, and QS dashboard.
+
+Deploy from a protected, reviewed commit:
+
+```bash
+fly deploy --config deploy/fly/field-pwa.production.fly.toml
+fly deploy --config deploy/fly/admin.production.fly.toml
+fly deploy --config deploy/fly/pm-dashboard.production.fly.toml
+fly deploy --config deploy/fly/qs-dashboard.production.fly.toml
+```
+
+## Domains And TLS
+
+Attach custom domains after each app deploy succeeds:
+
+```bash
+fly certs add field.batios.example --app batios-field-pwa
+fly certs add admin.batios.example --app batios-admin
+fly certs add pm.batios.example --app batios-pm-dashboard
+fly certs add qs.batios.example --app batios-qs-dashboard
+```
+
+Then configure DNS using the instructions returned by Fly, and verify each
+certificate:
+
+```bash
+fly certs check field.batios.example --app batios-field-pwa
+```
+
+Repeat for each hostname. Keep the `.fly.dev` URLs available for emergency
+operator access until domain routing has been stable for at least one release.
+
+## Smoke And Monitoring
+
+Export production URLs and run the existing health smoke check:
+
+```bash
+export BATIOS_FIELD_PWA_URL="https://field.batios.example"
+export BATIOS_ADMIN_URL="https://admin.batios.example"
+export BATIOS_PM_DASHBOARD_URL="https://pm.batios.example"
+export BATIOS_QS_DASHBOARD_URL="https://qs.batios.example"
+
+corepack pnpm staging:smoke
+```
+
+Before cutover, configure alerts for:
+
+- Any app `/healthz` endpoint returning non-2xx.
+- Fly deploy failures.
+- Machine restarts or crash loops.
+- Database backup failure or missing scheduled backup.
+- Database connection errors in app logs.
+- Smoke-check regression after deployment.
+
+Record the alert destination and on-call owner in the release notes.
+
+## Rollback
+
+Rollback restores the application image, not database state. If a deployment ran
+data migrations, prepare the data rollback or forward-fix separately before
+redeploying an older image.
+
+Application rollback:
+
+1. Find the previous good image with `fly releases --app <app-name>`.
+2. Redeploy that image with `fly deploy --image <image-ref> --app <app-name>`.
+3. Run `corepack pnpm staging:smoke` against production URLs.
+4. Check app logs and database connection health.
+5. Record the rollback image, operator, reason, and result.
+
+Database recovery:
+
+1. Restore the verified backup into a new production database or cluster.
+2. Attach one app to the restored database in a controlled window.
+3. Run smoke checks and targeted data integrity checks.
+4. Rotate `DATABASE_URL` for all production apps only after verification.
+
+## Go/No-Go
+
+Production is ready only when:
+
+- PR #26 or its successor is merged into `main`.
+- This checklist is complete for the target release.
+- Production database backup and restore is verified.
+- Production secrets are set and reviewed without exposing values.
+- Custom domains and TLS checks pass.
+- All four `/healthz` endpoints pass smoke checks.
+- Rollback owner and commands are confirmed.


### PR DESCRIPTION
## Summary
- add production Fly configs for Field PWA, Admin, PM dashboard, and QS dashboard
- add a production env placeholder file and allow it through .gitignore
- add an operator production cutover checklist covering database backups, secrets, domains/TLS, smoke checks, monitoring, and rollback
- link production requirements from docs/FLY.md

## Verification
- flyctl config validate --config deploy/fly/field-pwa.production.fly.toml
- flyctl config validate --config deploy/fly/admin.production.fly.toml
- flyctl config validate --config deploy/fly/pm-dashboard.production.fly.toml
- flyctl config validate --config deploy/fly/qs-dashboard.production.fly.toml
- corepack pnpm format:check

## Dependency
This PR targets feat/flyio-deployment-scaffold while PR #26 is awaiting review. Retarget to main after #26 merges.

Closes #27