### PR TITLE
Add manual production smoke gate

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,41 @@
+name: Production Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      field_pwa_url:
+        description: Field PWA production URL
+        required: false
+        type: string
+      admin_url:
+        description: Admin dashboard production URL
+        required: false
+        type: string
+      pm_dashboard_url:
+        description: PM dashboard production URL
+        required: false
+        type: string
+      qs_dashboard_url:
+        description: QS dashboard production URL
+        required: false
+        type: string
+
+jobs:
+  production-smoke:
+    runs-on: ubuntu-latest
+    env:
+      BATIOS_FIELD_PWA_URL: ${{ inputs.field_pwa_url || vars.BATIOS_PRODUCTION_FIELD_PWA_URL }}
+      BATIOS_ADMIN_URL: ${{ inputs.admin_url || vars.BATIOS_PRODUCTION_ADMIN_URL }}
+      BATIOS_PM_DASHBOARD_URL: ${{ inputs.pm_dashboard_url || vars.BATIOS_PRODUCTION_PM_DASHBOARD_URL }}
+      BATIOS_QS_DASHBOARD_URL: ${{ inputs.qs_dashboard_url || vars.BATIOS_PRODUCTION_QS_DASHBOARD_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.18.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm staging:smoke

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -127,6 +127,19 @@ export BATIOS_QS_DASHBOARD_URL="https://qs.batios.example"
 corepack pnpm staging:smoke
 ```
 
+Operators can also run the `Production Smoke` GitHub Actions workflow from the
+Actions tab. Provide the four production URLs as manual inputs, or configure
+these repository variables:
+
+- `BATIOS_PRODUCTION_FIELD_PWA_URL`
+- `BATIOS_PRODUCTION_ADMIN_URL`
+- `BATIOS_PRODUCTION_PM_DASHBOARD_URL`
+- `BATIOS_PRODUCTION_QS_DASHBOARD_URL`
+
+The workflow is manual-only until production domains are live and alert
+ownership is agreed. If URLs are missing, the smoke script fails before any
+network requests and names the missing values.
+
 Before cutover, configure alerts for:
 
 - Any app `/healthz` endpoint returning non-2xx.
@@ -148,7 +161,8 @@ Application rollback:
 
 1. Find the previous good image with `fly releases --app <app-name>`.
 2. Redeploy that image with `fly deploy --image <image-ref> --app <app-name>`.
-3. Run `corepack pnpm staging:smoke` against production URLs.
+3. Run `corepack pnpm staging:smoke` or the `Production Smoke` workflow against
+   production URLs.
 4. Check app logs and database connection health.
 5. Record the rollback image, operator, reason, and result.
 


### PR DESCRIPTION
## Summary
- add a manually dispatched Production Smoke GitHub Actions workflow
- read production URLs from workflow inputs or repository variables
- document how to use the production smoke gate during cutover and rollback

## Verification
- corepack pnpm format:check
- corepack pnpm staging:smoke using live Fly staging URLs as safe stand-ins: Field PWA 200, Admin dashboard 200, PM dashboard 200, QS dashboard 200

## Dependency
This PR is stacked on PR #30, which is stacked behind PR #28 and PR #26. Retarget through the stack as earlier PRs merge.

Closes #31