### PR TITLE
Add production release evidence template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.next
+**/.next
+dist
+**/dist
+node_modules
+**/node_modules
+coverage
+.env
+.env.*
+!.env.example
+!.env.staging.example
+*.tsbuildinfo
+**/*.tsbuildinfo

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,16 @@
+# Copy to the production provider secret store. Do not commit real values.
+
+BATIOS_ENVIRONMENT=production
+DATABASE_URL=postgres://batios_production:replace-me@production-db.example.com:5432/batios_production
+BATIOS_ORGANISATION_ID=00000000-0000-0000-0000-000000000000
+BATIOS_SESSION_SECRET=replace-with-32-byte-random-secret
+
+# Public app URLs used by smoke checks and cross-app navigation.
+BATIOS_FIELD_PWA_URL=https://field.batios.example
+BATIOS_ADMIN_URL=https://admin.batios.example
+BATIOS_PM_DASHBOARD_URL=https://pm.batios.example
+BATIOS_QS_DASHBOARD_URL=https://qs.batios.example
+
+# Optional until a hosted provider is wired behind packages/agent-gateway.
+BATIOS_AGENT_GATEWAY_PROVIDER=local
+BATIOS_AGENT_GATEWAY_MODEL=batios-local-production

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,0 +1,41 @@
+name: Production Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      field_pwa_url:
+        description: Field PWA production URL
+        required: false
+        type: string
+      admin_url:
+        description: Admin dashboard production URL
+        required: false
+        type: string
+      pm_dashboard_url:
+        description: PM dashboard production URL
+        required: false
+        type: string
+      qs_dashboard_url:
+        description: QS dashboard production URL
+        required: false
+        type: string
+
+jobs:
+  production-smoke:
+    runs-on: ubuntu-latest
+    env:
+      BATIOS_FIELD_PWA_URL: ${{ inputs.field_pwa_url || vars.BATIOS_PRODUCTION_FIELD_PWA_URL }}
+      BATIOS_ADMIN_URL: ${{ inputs.admin_url || vars.BATIOS_PRODUCTION_ADMIN_URL }}
+      BATIOS_PM_DASHBOARD_URL: ${{ inputs.pm_dashboard_url || vars.BATIOS_PRODUCTION_PM_DASHBOARD_URL }}
+      BATIOS_QS_DASHBOARD_URL: ${{ inputs.qs_dashboard_url || vars.BATIOS_PRODUCTION_QS_DASHBOARD_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.18.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm staging:smoke

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -1,0 +1,43 @@
+name: Staging Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      field_pwa_url:
+        description: Field PWA URL
+        required: false
+        type: string
+      admin_url:
+        description: Admin dashboard URL
+        required: false
+        type: string
+      pm_dashboard_url:
+        description: PM dashboard URL
+        required: false
+        type: string
+      qs_dashboard_url:
+        description: QS dashboard URL
+        required: false
+        type: string
+  schedule:
+    - cron: '17 * * * *'
+
+jobs:
+  staging-smoke:
+    runs-on: ubuntu-latest
+    env:
+      BATIOS_FIELD_PWA_URL: ${{ inputs.field_pwa_url || vars.BATIOS_FIELD_PWA_URL || 'https://batios-field-pwa-staging.fly.dev' }}
+      BATIOS_ADMIN_URL: ${{ inputs.admin_url || vars.BATIOS_ADMIN_URL || 'https://batios-admin-staging.fly.dev' }}
+      BATIOS_PM_DASHBOARD_URL: ${{ inputs.pm_dashboard_url || vars.BATIOS_PM_DASHBOARD_URL || 'https://batios-pm-dashboard-staging.fly.dev' }}
+      BATIOS_QS_DASHBOARD_URL: ${{ inputs.qs_dashboard_url || vars.BATIOS_QS_DASHBOARD_URL || 'https://batios-qs-dashboard-staging.fly.dev' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.18.0
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm staging:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ coverage/
 .env.*
 !.env.example
 !.env.staging.example
+!.env.production.example
 *.tsbuildinfo

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/field-pwa/next.config.mjs
+++ b/apps/field-pwa/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/pm-dashboard/next.config.mjs
+++ b/apps/pm-dashboard/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/apps/qs-dashboard/next.config.mjs
+++ b/apps/qs-dashboard/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  output: 'standalone',
   outputFileTracingRoot: fileURLToPath(new URL('../..', import.meta.url)),
   reactStrictMode: true,
 };

--- a/deploy/fly/Dockerfile.next
+++ b/deploy/fly/Dockerfile.next
@@ -1,0 +1,34 @@
+FROM node:20.18.0-bookworm-slim AS base
+WORKDIR /app
+RUN npm install --global pnpm@9.12.0
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+RUN pnpm install --frozen-lockfile
+
+FROM deps AS build
+ARG APP_DIR
+ARG PACKAGE_NAME
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm --filter @batios/design-system clean && pnpm --filter @batios/design-system build
+RUN pnpm --filter ${PACKAGE_NAME} build
+
+FROM node:20.18.0-bookworm-slim AS runner
+ARG APP_DIR
+ENV APP_DIR=${APP_DIR}
+ENV HOSTNAME=0.0.0.0
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=8080
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+
+COPY --from=build --chown=nextjs:nodejs /app/apps/${APP_DIR}/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/apps/${APP_DIR}/.next/static ./apps/${APP_DIR}/.next/static
+
+USER nextjs
+EXPOSE 8080
+CMD ["sh", "-c", "node apps/${APP_DIR}/server.js"]

--- a/deploy/fly/admin.fly.toml
+++ b/deploy/fly/admin.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-admin-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "admin"
+    PACKAGE_NAME = "@batios/admin"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/admin.production.fly.toml
+++ b/deploy/fly/admin.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-admin"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "admin"
+    PACKAGE_NAME = "@batios/admin"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/field-pwa.fly.toml
+++ b/deploy/fly/field-pwa.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-field-pwa-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "field-pwa"
+    PACKAGE_NAME = "@batios/field-pwa"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/field-pwa.production.fly.toml
+++ b/deploy/fly/field-pwa.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-field-pwa"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "field-pwa"
+    PACKAGE_NAME = "@batios/field-pwa"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/pm-dashboard.fly.toml
+++ b/deploy/fly/pm-dashboard.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-pm-dashboard-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "pm-dashboard"
+    PACKAGE_NAME = "@batios/pm-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/pm-dashboard.production.fly.toml
+++ b/deploy/fly/pm-dashboard.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-pm-dashboard"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "pm-dashboard"
+    PACKAGE_NAME = "@batios/pm-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/qs-dashboard.fly.toml
+++ b/deploy/fly/qs-dashboard.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-qs-dashboard-staging"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "qs-dashboard"
+    PACKAGE_NAME = "@batios/qs-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "staging"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/deploy/fly/qs-dashboard.production.fly.toml
+++ b/deploy/fly/qs-dashboard.production.fly.toml
@@ -1,0 +1,29 @@
+app = "batios-qs-dashboard"
+primary_region = "jnb"
+
+[build]
+  dockerfile = "Dockerfile.next"
+  [build.args]
+    APP_DIR = "qs-dashboard"
+    PACKAGE_NAME = "@batios/qs-dashboard"
+
+[env]
+  BATIOS_ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 100
+    hard_limit = 150
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -1,0 +1,87 @@
+# Fly.io Deployment
+
+BatiOS deploys to Fly.io as four Next.js apps plus one PostgreSQL 16 database.
+Each app uses the shared Dockerfile at `deploy/fly/Dockerfile.next` and its own
+Fly config.
+
+## Apps
+
+| Surface      | Fly config                         | Staging app name              |
+| ------------ | ---------------------------------- | ----------------------------- |
+| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `batios-field-pwa-staging`    |
+| Admin        | `deploy/fly/admin.fly.toml`        | `batios-admin-staging`        |
+| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `batios-pm-dashboard-staging` |
+| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `batios-qs-dashboard-staging` |
+
+## One-Time Setup
+
+Install and authenticate the Fly CLI:
+
+```bash
+fly auth login
+```
+
+Create the staging Postgres app:
+
+```bash
+fly postgres create \
+  --name batios-postgres-staging \
+  --region jnb \
+  --initial-cluster-size 1 \
+  --vm-size shared-cpu-1x \
+  --volume-size 10
+```
+
+Enable managed backups before production cutover. Some Fly CLI versions require
+Tigris terms acceptance before `--enable-backups` works during `postgres create`;
+use the Fly dashboard, a newer CLI, or Managed Postgres if the CLI cannot enable
+backups non-interactively.
+
+Create the four staging apps without deploying:
+
+```bash
+fly apps create batios-field-pwa-staging
+fly apps create batios-admin-staging
+fly apps create batios-pm-dashboard-staging
+fly apps create batios-qs-dashboard-staging
+```
+
+Set required runtime secrets on each app. Use the generated Fly Postgres
+connection string for `DATABASE_URL`.
+
+```bash
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  BATIOS_ORGANISATION_ID="00000000-0000-0000-0000-000000000000" \
+  BATIOS_SESSION_SECRET="replace-with-32-byte-random-secret" \
+  --app batios-field-pwa-staging
+```
+
+Repeat `fly secrets set` for the Admin, PM, and QS apps.
+
+## Deploy
+
+Deploy each app from the repository root:
+
+```bash
+fly deploy --config deploy/fly/field-pwa.fly.toml
+fly deploy --config deploy/fly/admin.fly.toml
+fly deploy --config deploy/fly/pm-dashboard.fly.toml
+fly deploy --config deploy/fly/qs-dashboard.fly.toml
+```
+
+## Verify
+
+Export staging URLs and run the smoke check:
+
+```bash
+export BATIOS_FIELD_PWA_URL="https://batios-field-pwa-staging.fly.dev"
+export BATIOS_ADMIN_URL="https://batios-admin-staging.fly.dev"
+export BATIOS_PM_DASHBOARD_URL="https://batios-pm-dashboard-staging.fly.dev"
+export BATIOS_QS_DASHBOARD_URL="https://batios-qs-dashboard-staging.fly.dev"
+
+corepack pnpm staging:smoke
+```
+
+The smoke check calls each app's `/healthz` endpoint and validates the JSON
+health contract.

--- a/docs/FLY.md
+++ b/docs/FLY.md
@@ -6,12 +6,14 @@ Fly config.
 
 ## Apps
 
-| Surface      | Fly config                         | Staging app name              |
-| ------------ | ---------------------------------- | ----------------------------- |
-| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `batios-field-pwa-staging`    |
-| Admin        | `deploy/fly/admin.fly.toml`        | `batios-admin-staging`        |
-| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `batios-pm-dashboard-staging` |
-| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `batios-qs-dashboard-staging` |
+| Surface      | Staging config                     | Production config                             |
+| ------------ | ---------------------------------- | --------------------------------------------- |
+| Field PWA    | `deploy/fly/field-pwa.fly.toml`    | `deploy/fly/field-pwa.production.fly.toml`    |
+| Admin        | `deploy/fly/admin.fly.toml`        | `deploy/fly/admin.production.fly.toml`        |
+| PM dashboard | `deploy/fly/pm-dashboard.fly.toml` | `deploy/fly/pm-dashboard.production.fly.toml` |
+| QS dashboard | `deploy/fly/qs-dashboard.fly.toml` | `deploy/fly/qs-dashboard.production.fly.toml` |
+
+Production cutover requirements live in `docs/PRODUCTION.md`.
 
 ## One-Time Setup
 

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,0 +1,172 @@
+# Production Cutover Checklist
+
+This checklist promotes the Fly.io staging deployment into a production-ready
+operating model. Do not route real users or critical data to production until
+every required item is complete.
+
+## Production Surfaces
+
+| Surface      | Fly config                                    | Production app name   | Example domain         |
+| ------------ | --------------------------------------------- | --------------------- | ---------------------- |
+| Field PWA    | `deploy/fly/field-pwa.production.fly.toml`    | `batios-field-pwa`    | `field.batios.example` |
+| Admin        | `deploy/fly/admin.production.fly.toml`        | `batios-admin`        | `admin.batios.example` |
+| PM dashboard | `deploy/fly/pm-dashboard.production.fly.toml` | `batios-pm-dashboard` | `pm.batios.example`    |
+| QS dashboard | `deploy/fly/qs-dashboard.production.fly.toml` | `batios-qs-dashboard` | `qs.batios.example`    |
+
+Production configs intentionally set `BATIOS_ENVIRONMENT=production`,
+`auto_stop_machines="off"`, and `min_machines_running=1` so production traffic
+does not wait for cold starts. Revisit machine count, memory, and CPU after the
+first real load profile is measured.
+
+## Database Gate
+
+Production must use a verified backup and restore path before cutover.
+
+Recommended path:
+
+1. Provision Fly Managed Postgres for production.
+2. Store the Managed Postgres connection string as `DATABASE_URL` on each
+   production app.
+3. Verify automated backups are enabled in Fly.
+4. Perform a restore rehearsal into a separate database or cluster.
+5. Record the restore timestamp, operator, and verification result in the
+   release notes.
+
+Fallback path for unmanaged Fly Postgres:
+
+1. Enable backups with `fly postgres backup enable --app <postgres-app>`.
+2. Create a manual backup with `fly postgres backup create --app <postgres-app>`.
+3. List backups with `fly postgres backup list --app <postgres-app>`.
+4. Restore into a new cluster with `fly postgres backup restore`.
+5. Attach a non-production app to the restored database and run smoke checks.
+
+If backup enablement is blocked by CLI or account terms, stop the cutover and
+resolve it in the Fly dashboard or with Fly support. Do not accept volume
+snapshots alone as the only production recovery path.
+
+## Secret Checklist
+
+Set these values through Fly secrets or another approved provider secret store.
+Never commit real values.
+
+| Name                            | Required | Production rule                                       |
+| ------------------------------- | -------- | ----------------------------------------------------- |
+| `DATABASE_URL`                  | Yes      | Production database only; no staging credentials.     |
+| `BATIOS_ORGANISATION_ID`        | Yes      | Real default organisation or controlled bootstrap ID. |
+| `BATIOS_SESSION_SECRET`         | Yes      | Unique 32-byte minimum random value.                  |
+| `BATIOS_AGENT_GATEWAY_PROVIDER` | Optional | Real provider only after audit path is approved.      |
+| `BATIOS_AGENT_GATEWAY_MODEL`    | Optional | Production-approved model identifier.                 |
+
+Use `.env.production.example` only as the shape of required configuration.
+
+## App Provisioning
+
+Create production apps once:
+
+```bash
+fly apps create batios-field-pwa
+fly apps create batios-admin
+fly apps create batios-pm-dashboard
+fly apps create batios-qs-dashboard
+```
+
+Set secrets on each app:
+
+```bash
+fly secrets set \
+  DATABASE_URL="postgres://..." \
+  BATIOS_ORGANISATION_ID="00000000-0000-0000-0000-000000000000" \
+  BATIOS_SESSION_SECRET="replace-with-production-secret" \
+  BATIOS_AGENT_GATEWAY_PROVIDER="local" \
+  BATIOS_AGENT_GATEWAY_MODEL="batios-local-production" \
+  --app batios-field-pwa
+```
+
+Repeat for Admin, PM dashboard, and QS dashboard.
+
+Deploy from a protected, reviewed commit:
+
+```bash
+fly deploy --config deploy/fly/field-pwa.production.fly.toml
+fly deploy --config deploy/fly/admin.production.fly.toml
+fly deploy --config deploy/fly/pm-dashboard.production.fly.toml
+fly deploy --config deploy/fly/qs-dashboard.production.fly.toml
+```
+
+## Domains And TLS
+
+Attach custom domains after each app deploy succeeds:
+
+```bash
+fly certs add field.batios.example --app batios-field-pwa
+fly certs add admin.batios.example --app batios-admin
+fly certs add pm.batios.example --app batios-pm-dashboard
+fly certs add qs.batios.example --app batios-qs-dashboard
+```
+
+Then configure DNS using the instructions returned by Fly, and verify each
+certificate:
+
+```bash
+fly certs check field.batios.example --app batios-field-pwa
+```
+
+Repeat for each hostname. Keep the `.fly.dev` URLs available for emergency
+operator access until domain routing has been stable for at least one release.
+
+## Smoke And Monitoring
+
+Export production URLs and run the existing health smoke check:
+
+```bash
+export BATIOS_FIELD_PWA_URL="https://field.batios.example"
+export BATIOS_ADMIN_URL="https://admin.batios.example"
+export BATIOS_PM_DASHBOARD_URL="https://pm.batios.example"
+export BATIOS_QS_DASHBOARD_URL="https://qs.batios.example"
+
+corepack pnpm staging:smoke
+```
+
+Before cutover, configure alerts for:
+
+- Any app `/healthz` endpoint returning non-2xx.
+- Fly deploy failures.
+- Machine restarts or crash loops.
+- Database backup failure or missing scheduled backup.
+- Database connection errors in app logs.
+- Smoke-check regression after deployment.
+
+Record the alert destination and on-call owner in the release notes.
+
+## Rollback
+
+Rollback restores the application image, not database state. If a deployment ran
+data migrations, prepare the data rollback or forward-fix separately before
+redeploying an older image.
+
+Application rollback:
+
+1. Find the previous good image with `fly releases --app <app-name>`.
+2. Redeploy that image with `fly deploy --image <image-ref> --app <app-name>`.
+3. Run `corepack pnpm staging:smoke` against production URLs.
+4. Check app logs and database connection health.
+5. Record the rollback image, operator, reason, and result.
+
+Database recovery:
+
+1. Restore the verified backup into a new production database or cluster.
+2. Attach one app to the restored database in a controlled window.
+3. Run smoke checks and targeted data integrity checks.
+4. Rotate `DATABASE_URL` for all production apps only after verification.
+
+## Go/No-Go
+
+Production is ready only when:
+
+- PR #26 or its successor is merged into `main`.
+- This checklist is complete for the target release.
+- Production database backup and restore is verified.
+- Production secrets are set and reviewed without exposing values.
+- Custom domains and TLS checks pass.
+- All four `/healthz` endpoints pass smoke checks.
+- Rollback owner and commands are confirmed.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -127,6 +127,19 @@ export BATIOS_QS_DASHBOARD_URL="https://qs.batios.example"
 corepack pnpm staging:smoke
 ```
 
+Operators can also run the `Production Smoke` GitHub Actions workflow from the
+Actions tab. Provide the four production URLs as manual inputs, or configure
+these repository variables:
+
+- `BATIOS_PRODUCTION_FIELD_PWA_URL`
+- `BATIOS_PRODUCTION_ADMIN_URL`
+- `BATIOS_PRODUCTION_PM_DASHBOARD_URL`
+- `BATIOS_PRODUCTION_QS_DASHBOARD_URL`
+
+The workflow is manual-only until production domains are live and alert
+ownership is agreed. If URLs are missing, the smoke script fails before any
+network requests and names the missing values.
+
 Before cutover, configure alerts for:
 
 - Any app `/healthz` endpoint returning non-2xx.
@@ -148,7 +161,8 @@ Application rollback:
 
 1. Find the previous good image with `fly releases --app <app-name>`.
 2. Redeploy that image with `fly deploy --image <image-ref> --app <app-name>`.
-3. Run `corepack pnpm staging:smoke` against production URLs.
+3. Run `corepack pnpm staging:smoke` or the `Production Smoke` workflow against
+   production URLs.
 4. Check app logs and database connection health.
 5. Record the rollback image, operator, reason, and result.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -23,6 +23,14 @@ corepack pnpm compliance:scan
 3. Run `corepack pnpm staging:smoke` against deployed staging URLs.
 4. Confirm Field PWA, Admin, PM, and QS surfaces return healthy status codes.
 
+## Production Evidence
+
+For production releases, copy `docs/templates/production-release-evidence.md`
+and complete it before go/no-go signoff. The completed record must include the
+reviewed commit, linked PRs, backup and restore evidence, smoke results,
+monitoring checks, rollback owner, and signoffs. Do not include secret values or
+customer data.
+
 ## Review Requirements
 
 - Pull request links to the tracked issue.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -48,6 +48,8 @@ corepack pnpm compliance:scan
 
 ## Staging Smoke Check
 
+Fly.io deployment steps live in `docs/FLY.md`.
+
 After deployment, export the four public app URLs and run:
 
 ```bash

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -67,6 +67,30 @@ Each endpoint must return a 2xx or 3xx status and a JSON payload with the
 expected service name, `status: "ok"`, and a valid `checkedAt` timestamp. The
 script does not require or print secret values.
 
+## Automated Smoke Monitor
+
+The `Staging Smoke` GitHub Actions workflow runs `corepack pnpm staging:smoke`
+on a schedule and can also be started manually from the Actions tab.
+
+By default, the workflow checks the Fly staging URLs:
+
+- `https://batios-field-pwa-staging.fly.dev`
+- `https://batios-admin-staging.fly.dev`
+- `https://batios-pm-dashboard-staging.fly.dev`
+- `https://batios-qs-dashboard-staging.fly.dev`
+
+Operators can override those defaults with repository variables:
+
+- `BATIOS_FIELD_PWA_URL`
+- `BATIOS_ADMIN_URL`
+- `BATIOS_PM_DASHBOARD_URL`
+- `BATIOS_QS_DASHBOARD_URL`
+
+Manual runs can also override the four URLs with workflow inputs. A failed run
+means at least one `/healthz` endpoint is unreachable, returned a non-2xx/3xx
+status, or returned an invalid health payload. Check the failed job log, inspect
+the affected Fly app logs, and rerun the workflow after recovery.
+
 ## Readiness Criteria
 
 Staging is ready for E2E work when:

--- a/docs/templates/production-release-evidence.md
+++ b/docs/templates/production-release-evidence.md
@@ -1,0 +1,87 @@
+# Production Release Evidence
+
+Copy this template for every production release. Store completed records in the
+release notes, an issue comment, or another approved audit location. Do not add
+secret values, credentials, tokens, or customer data.
+
+## Release Identity
+
+| Field           | Value |
+| --------------- | ----- |
+| Release date    |       |
+| Release owner   |       |
+| Incident owner  |       |
+| Main commit SHA |       |
+| Pull requests   |       |
+| Issues closed   |       |
+| Fly apps        |       |
+
+## Build And Review Gates
+
+| Gate              | Result | Evidence link or note |
+| ----------------- | ------ | --------------------- |
+| `qa`              |        |                       |
+| `qa-agent`        |        |                       |
+| Required review   |        |                       |
+| Branch protection |        |                       |
+| Secrets scan      |        |                       |
+| Release checklist |        |                       |
+
+## Database Backup And Restore Evidence
+
+| Field                         | Value |
+| ----------------------------- | ----- |
+| Database provider             |       |
+| Production database app/name  |       |
+| Backups enabled               |       |
+| Latest backup timestamp       |       |
+| Restore rehearsal target      |       |
+| Restore rehearsal timestamp   |       |
+| Restore verification operator |       |
+| Restore verification result   |       |
+
+## Deployment Evidence
+
+| Surface      | App name | Image or release id | Deploy result | URL |
+| ------------ | -------- | ------------------- | ------------- | --- |
+| Field PWA    |          |                     |               |     |
+| Admin        |          |                     |               |     |
+| PM dashboard |          |                     |               |     |
+| QS dashboard |          |                     |               |     |
+
+## Smoke And Monitoring
+
+| Check                    | Result | Evidence link or note |
+| ------------------------ | ------ | --------------------- |
+| Staging smoke            |        |                       |
+| Production smoke         |        |                       |
+| Domain/TLS verification  |        |                       |
+| App health alerts        |        |                       |
+| Database backup alerts   |        |                       |
+| Database connection logs |        |                       |
+
+## Rollback Plan
+
+| Field                      | Value |
+| -------------------------- | ----- |
+| Rollback owner             |       |
+| Previous good app releases |       |
+| Database rollback required |       |
+| Backup restore target      |       |
+| Rollback smoke command     |       |
+| Communications owner       |       |
+
+## Go/No-Go
+
+| Signoff             | Name | Decision | Timestamp |
+| ------------------- | ---- | -------- | --------- |
+| Release owner       |      |          |           |
+| Platform owner      |      |          |           |
+| Operations owner    |      |          |           |
+| Compliance reviewer |      |          |           |
+
+## Notes
+
+- Decisions:
+- Exceptions:
+- Follow-up issues:


### PR DESCRIPTION
## Summary
- add a copyable production release evidence template
- capture release identity, required checks, backup/restore proof, deployments, smoke/monitoring, rollback ownership, and go/no-go signoff
- link the evidence template from docs/RELEASE.md

## Verification
- corepack pnpm format:check

## Dependency
This PR is stacked on PR #32, which is stacked behind PR #30, PR #28, and PR #26. Retarget through the stack as earlier PRs merge.

Closes #33