### PR TITLE
Add production database backup runbook

### DIFF
--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -21,6 +21,8 @@ first real load profile is measured.
 ## Database Gate
 
 Production must use a verified backup and restore path before cutover.
+The database decision and restore rehearsal runbook lives in
+`docs/PRODUCTION_DATABASE.md`.
 
 Recommended path:
 

--- a/docs/PRODUCTION_DATABASE.md
+++ b/docs/PRODUCTION_DATABASE.md
@@ -1,0 +1,134 @@
+# Production Database Runbook
+
+This runbook controls the BatiOS production database decision, provisioning, and
+backup verification on Fly.io. Do not provision paid database resources or move
+production traffic until the decision record is complete.
+
+## Current State
+
+| Item                    | Status                                      |
+| ----------------------- | ------------------------------------------- |
+| Staging database        | `batios-postgres-staging`, unmanaged Fly PG |
+| Staging region          | `jnb`                                       |
+| Managed Postgres        | No cluster currently exists                 |
+| Production database     | Not provisioned                             |
+| Production backup proof | Not verified                                |
+
+Fly platform regions include `jnb`, `fra`, `lhr`, `ams`, `iad`, `ord`, `sin`,
+and others. Fly Managed Postgres availability can differ from general app
+regions, so confirm the target region immediately before provisioning.
+
+## Decision Record
+
+Complete this before creating a production database:
+
+| Decision                    | Value |
+| --------------------------- | ----- |
+| Database provider           |       |
+| Region                      |       |
+| Plan                        |       |
+| Storage size                |       |
+| App region alignment        |       |
+| Backup mechanism            |       |
+| Restore rehearsal target    |       |
+| Expected monthly cost       |       |
+| Decision owner              |       |
+| Decision timestamp          |       |
+| Approval link or issue note |       |
+
+Recommended default: Fly Managed Postgres, Postgres 16, smallest acceptable
+production plan, 10 GB initial storage, and an application region close to the
+database region. If `jnb` is not available for Managed Postgres, choose between
+moving production apps near the database or accepting cross-region latency from
+`jnb`.
+
+## Option A: Fly Managed Postgres
+
+Use this path when Managed Postgres is available in an acceptable region. It is
+preferred for production because Fly manages backups, recovery, HA/failover,
+monitoring, and support.
+
+Provision:
+
+```bash
+fly mpg create \
+  --name batios-production-db \
+  --org personal \
+  --region <region> \
+  --pg-major-version 16 \
+  --plan <plan> \
+  --volume-size 10
+```
+
+Attach or set the database URL only through provider secrets. Do not commit the
+connection string.
+
+```bash
+fly mpg attach <cluster-id> --app batios-field-pwa
+fly mpg attach <cluster-id> --app batios-admin
+fly mpg attach <cluster-id> --app batios-pm-dashboard
+fly mpg attach <cluster-id> --app batios-qs-dashboard
+```
+
+Verify backups:
+
+```bash
+fly mpg backup list <cluster-id>
+fly mpg backup create <cluster-id>
+fly mpg backup list <cluster-id>
+```
+
+Restore rehearsal:
+
+```bash
+fly mpg restore <cluster-id> --backup-id <backup-id>
+```
+
+Record the restore target and verification result in
+`docs/templates/production-release-evidence.md`.
+
+## Option B: Unmanaged Fly Postgres
+
+Use this path only if region affinity to `jnb` is more important than the
+Managed Postgres operating model, and only after backups and restore rehearsal
+are proven.
+
+Provision:
+
+```bash
+fly postgres create \
+  --name batios-postgres-production \
+  --region jnb \
+  --initial-cluster-size 1 \
+  --vm-size shared-cpu-1x \
+  --volume-size 10
+```
+
+Enable and verify backups:
+
+```bash
+fly postgres backup enable --app batios-postgres-production
+fly postgres backup create --app batios-postgres-production
+fly postgres backup list --app batios-postgres-production
+```
+
+Restore rehearsal:
+
+```bash
+fly postgres backup restore batios-postgres-production-restore \
+  --app batios-postgres-production \
+  --restore-target-name <backup-id>
+```
+
+Attach production apps only after the restore rehearsal succeeds.
+
+## Go/No-Go Gate
+
+Production database is ready only when:
+
+- Provider, region, plan, and cost are approved in issue #35.
+- `DATABASE_URL` is stored only in Fly secrets or approved secret storage.
+- Backup creation is verified.
+- Restore rehearsal succeeds into a separate target.
+- Restore evidence is captured in the production release evidence template.
+- Production smoke checks pass after apps are connected to the database.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,6 +31,9 @@ reviewed commit, linked PRs, backup and restore evidence, smoke results,
 monitoring checks, rollback owner, and signoffs. Do not include secret values or
 customer data.
 
+Production database provider, region, backup, and restore rehearsal decisions
+must follow `docs/PRODUCTION_DATABASE.md`.
+
 ## Review Requirements
 
 - Pull request links to the tracked issue.


### PR DESCRIPTION
## Summary
- add a production database decision and backup verification runbook
- document Managed Postgres as the preferred production path and unmanaged Fly Postgres as a jnb-only fallback requiring backup proof
- link database decision requirements from production and release docs

## Verification
- flyctl platform regions
- flyctl mpg create --help
- corepack pnpm format:check

## Notes
This PR does not provision paid production database resources. It prepares issue #35 for an explicit provider/region/cost decision before provisioning.

Refs #35