### PR TITLE
Record Managed Postgres colocation decision

### DIFF
--- a/deploy/fly/admin.production.fly.toml
+++ b/deploy/fly/admin.production.fly.toml
@@ -1,5 +1,5 @@
 app = "batios-admin"
-primary_region = "jnb"
+primary_region = "lhr"
 
 [build]
   dockerfile = "Dockerfile.next"

--- a/deploy/fly/field-pwa.production.fly.toml
+++ b/deploy/fly/field-pwa.production.fly.toml
@@ -1,5 +1,5 @@
 app = "batios-field-pwa"
-primary_region = "jnb"
+primary_region = "lhr"
 
 [build]
   dockerfile = "Dockerfile.next"

--- a/deploy/fly/pm-dashboard.production.fly.toml
+++ b/deploy/fly/pm-dashboard.production.fly.toml
@@ -1,5 +1,5 @@
 app = "batios-pm-dashboard"
-primary_region = "jnb"
+primary_region = "lhr"
 
 [build]
   dockerfile = "Dockerfile.next"

--- a/deploy/fly/qs-dashboard.production.fly.toml
+++ b/deploy/fly/qs-dashboard.production.fly.toml
@@ -1,5 +1,5 @@
 app = "batios-qs-dashboard"
-primary_region = "jnb"
+primary_region = "lhr"
 
 [build]
   dockerfile = "Dockerfile.next"

--- a/docs/PRODUCTION_DATABASE.md
+++ b/docs/PRODUCTION_DATABASE.md
@@ -22,25 +22,24 @@ regions, so confirm the target region immediately before provisioning.
 
 Complete this before creating a production database:
 
-| Decision                    | Value |
-| --------------------------- | ----- |
-| Database provider           |       |
-| Region                      |       |
-| Plan                        |       |
-| Storage size                |       |
-| App region alignment        |       |
-| Backup mechanism            |       |
-| Restore rehearsal target    |       |
-| Expected monthly cost       |       |
-| Decision owner              |       |
-| Decision timestamp          |       |
-| Approval link or issue note |       |
+| Decision                    | Value                                                                    |
+| --------------------------- | ------------------------------------------------------------------------ |
+| Database provider           | Fly Managed Postgres                                                     |
+| Region                      | `lhr`                                                                    |
+| Plan                        | Basic (`basic` in `fly mpg create`)                                      |
+| Storage size                | 10 GB                                                                    |
+| App region alignment        | Colocate production apps in `lhr`                                        |
+| Backup mechanism            | Fly Managed Postgres automated backups plus manual backup before cutover |
+| Restore rehearsal target    | Separate restored Managed Postgres cluster before cutover                |
+| Expected monthly cost       | About $38/month plus 10 GB provisioned storage                           |
+| Decision owner              | LinkAfrica operator                                                      |
+| Decision timestamp          | 2026-04-28                                                               |
+| Approval link or issue note | Issue #35                                                                |
 
-Recommended default: Fly Managed Postgres, Postgres 16, smallest acceptable
-production plan, 10 GB initial storage, and an application region close to the
-database region. If `jnb` is not available for Managed Postgres, choose between
-moving production apps near the database or accepting cross-region latency from
-`jnb`.
+Production decision: Fly Managed Postgres, Postgres 16, Basic plan, 10 GB
+initial storage, and production apps colocated in `lhr`. This avoids
+application-to-database cross-region latency after cutover and keeps production
+on the managed backup and recovery path.
 
 ## Option A: Fly Managed Postgres
 
@@ -54,9 +53,9 @@ Provision:
 fly mpg create \
   --name batios-production-db \
   --org personal \
-  --region <region> \
+  --region lhr \
   --pg-major-version 16 \
-  --plan <plan> \
+  --plan basic \
   --volume-size 10
 ```
 


### PR DESCRIPTION
## Summary
- record the production database decision for issue #35: Fly Managed Postgres, Postgres 16, basic plan, 10 GB storage, lhr region
- colocate all production Fly app configs in lhr to avoid app-to-database cross-region latency
- update the production database provisioning command to use --region lhr and --plan basic

## Verification
- flyctl config validate --config deploy/fly/field-pwa.production.fly.toml
- flyctl config validate --config deploy/fly/admin.production.fly.toml
- flyctl config validate --config deploy/fly/pm-dashboard.production.fly.toml
- flyctl config validate --config deploy/fly/qs-dashboard.production.fly.toml
- corepack pnpm format:check

## Notes
This records the provider/region/cost decision only. It does not provision paid Managed Postgres resources yet.

Refs #35