### PR TITLE
Add evidence vision foundation

### DIFF
--- a/docs/EVIDENCE_VISION.md
+++ b/docs/EVIDENCE_VISION.md
@@ -1,0 +1,50 @@
+# Evidence Vision
+
+`@batios/evidence-vision` defines the first computer vision boundary for BatiOS
+evidence workflows. The package is provider-neutral: it describes auditable
+requests, provider adapters, policy checks, observations, provenance, and audit
+events without binding production to a specific AI vendor.
+
+## First Use Cases
+
+- Site progress verification from field photos and videos.
+- Defect and safety risk screening.
+- Quantity assistance for counts and approximate measurements.
+- Geo-time and duplicate evidence integrity signals.
+- Before/after comparison across inspection dates.
+
+## Operating Rule
+
+Vision output is an observation, not the evidence itself. It must never overwrite
+the source artifact and must not become final payment, compliance, or rejection
+authority by itself. Every observation is traceable to source artifacts and can
+be routed for human review.
+
+## Request Contract
+
+Every analysis request requires:
+
+- `requestId`, `organisationId`, `projectId`, and `actorUserId`.
+- A purpose such as `site-progress-verification` or `defect-detection`.
+- A custody scope and policy tags.
+- One or more image/video artifacts with stable artifact IDs.
+- A provider and model name.
+
+## Observation Contract
+
+Each observation includes:
+
+- Source `artifactId`.
+- Observation kind and label.
+- Human-readable summary.
+- Confidence from `0` to `1`.
+- Optional severity, bounding box, and measured value.
+- `reviewRequired`, which should be true for safety, payment, low-confidence, or
+  compliance-sensitive outcomes.
+
+## Provider Path
+
+The first production adapter should be added behind the package interfaces and
+routed through policy and audit sinks. Provider responses should be retained as
+case records only when the request metadata allows it, and artifacts must not be
+used for model training unless a future tenant policy explicitly permits it.

--- a/packages/evidence-vision/package.json
+++ b/packages/evidence-vision/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@batios/evidence-vision",
+  "version": "0.0.0-foundation",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "test": "vitest run --passWithNoTests",
+    "test:integration": "vitest run --passWithNoTests --dir test/integration",
+    "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
+  }
+}

--- a/packages/evidence-vision/src/index.test.ts
+++ b/packages/evidence-vision/src/index.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertAuditableVisionRequest,
+  createEvidenceVision,
+  requiresHumanReview,
+  type EvidenceVisionAuditEvent,
+  type EvidenceVisionProviderClient,
+  type EvidenceVisionRequest,
+} from './index.js';
+
+const requestedAt = new Date('2026-04-29T09:00:00.000Z');
+const completedAt = new Date('2026-04-29T09:00:02.000Z');
+
+function baseRequest(overrides: Partial<EvidenceVisionRequest> = {}): EvidenceVisionRequest {
+  return {
+    provider: 'local',
+    model: 'batios-vision-local',
+    artifacts: [
+      {
+        artifactId: 'artifact_01',
+        type: 'image',
+        uri: 's3://batios-evidence/project-01/photo-01.jpg',
+        sha256: 'a'.repeat(64),
+        capturedAt: new Date('2026-04-29T08:59:00.000Z'),
+        capturedByUserId: 'user_01',
+        location: {
+          latitude: 5.6037,
+          longitude: -0.187,
+          accuracyMeters: 8,
+        },
+        declaredWorkItemId: 'work_01',
+      },
+    ],
+    metadata: {
+      requestId: 'vision_req_01',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      purpose: 'site-progress-verification',
+      custodyScope: 'project-joint-custody',
+      policyTags: ['no-training', 'human-review-required'],
+      retention: 'audit-log',
+      requestedAt,
+      traceId: 'trace_vision_01',
+    },
+    ...overrides,
+  };
+}
+
+describe('evidence vision boundary', () => {
+  it('requires auditable metadata and at least one artifact', () => {
+    expect(() =>
+      assertAuditableVisionRequest(
+        baseRequest({
+          artifacts: [],
+        }),
+      ),
+    ).toThrow('artifacts must contain at least one artifact');
+
+    expect(() =>
+      assertAuditableVisionRequest(
+        baseRequest({
+          metadata: {
+            ...baseRequest().metadata,
+            policyTags: [],
+          },
+        }),
+      ),
+    ).toThrow('metadata.policyTags must contain at least one policy tag');
+  });
+
+  it('routes provider calls through policy and audit hooks', async () => {
+    const events: EvidenceVisionAuditEvent[] = [];
+    const providerCalls: EvidenceVisionRequest[] = [];
+    const provider: EvidenceVisionProviderClient = {
+      async analyze(request) {
+        providerCalls.push(request);
+        return {
+          requestId: 'provider-id',
+          provider: 'local',
+          model: 'provider-model',
+          observations: [
+            {
+              observationId: 'obs_01',
+              artifactId: 'artifact_01',
+              kind: 'progress-indicator',
+              label: 'Drainage trench visible',
+              summary: 'The image shows an excavated drainage trench along the road shoulder.',
+              confidence: 0.91,
+              severity: 'info',
+              reviewRequired: true,
+              recommendedAction: 'Confirm trench dimensions before payment certification.',
+            },
+          ],
+          provenance: {
+            sourceArtifactIds: ['provider-artifact-id'],
+            modelVersion: 'local-test',
+          },
+          completedAt,
+        };
+      },
+    };
+
+    const vision = createEvidenceVision({
+      providers: {
+        local: provider,
+        openai: undefined,
+        google: undefined,
+        aws: undefined,
+        azure: undefined,
+      },
+      auditSink: {
+        async record(event) {
+          events.push(event);
+        },
+      },
+      policy: {
+        async evaluate(request) {
+          return { allowed: request.metadata.custodyScope === 'project-joint-custody' };
+        },
+      },
+    });
+
+    const response = await vision.analyze(baseRequest());
+
+    expect(providerCalls).toHaveLength(1);
+    expect(response).toMatchObject({
+      requestId: 'vision_req_01',
+      provider: 'local',
+      model: 'batios-vision-local',
+      provenance: {
+        sourceArtifactIds: ['artifact_01'],
+      },
+    });
+    expect(events.map((event) => event.outcome)).toEqual(['accepted', 'completed']);
+    expect(events[0]).toMatchObject({
+      requestId: 'vision_req_01',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      artifactIds: ['artifact_01'],
+      purpose: 'site-progress-verification',
+      custodyScope: 'project-joint-custody',
+      retention: 'audit-log',
+    });
+    expect(events[1]).toMatchObject({
+      outcome: 'completed',
+      completedAt,
+      observationCount: 1,
+      reviewRequired: true,
+    });
+  });
+
+  it('audits rejected requests without calling the provider', async () => {
+    const events: EvidenceVisionAuditEvent[] = [];
+    const providerCalls: EvidenceVisionRequest[] = [];
+    const vision = createEvidenceVision({
+      providers: {
+        local: {
+          async analyze(request) {
+            providerCalls.push(request);
+            throw new Error('should not call provider');
+          },
+        },
+        openai: undefined,
+        google: undefined,
+        aws: undefined,
+        azure: undefined,
+      },
+      auditSink: {
+        async record(event) {
+          events.push(event);
+        },
+      },
+      policy: {
+        async evaluate() {
+          return { allowed: false, reason: 'artifact custody is not approved' };
+        },
+      },
+    });
+
+    await expect(vision.analyze(baseRequest())).rejects.toThrow('artifact custody is not approved');
+
+    expect(providerCalls).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      outcome: 'rejected',
+      reason: 'artifact custody is not approved',
+    });
+  });
+
+  it('requires human review for lower confidence observations', async () => {
+    expect(
+      requiresHumanReview([
+        {
+          observationId: 'obs_02',
+          artifactId: 'artifact_01',
+          kind: 'defect-risk',
+          label: 'Possible concrete cracking',
+          summary: 'A visible line may indicate a surface crack.',
+          confidence: 0.72,
+          severity: 'medium',
+          reviewRequired: false,
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/evidence-vision/src/index.ts
+++ b/packages/evidence-vision/src/index.ts
@@ -1,0 +1,320 @@
+export const evidenceVisionBoundary = 'evidence-vision';
+
+export type EvidenceVisionProvider = 'local' | 'openai' | 'google' | 'aws' | 'azure';
+
+export type EvidenceVisionPurpose =
+  | 'site-progress-verification'
+  | 'defect-detection'
+  | 'safety-compliance'
+  | 'quantity-assistance'
+  | 'tamper-screening'
+  | 'before-after-comparison';
+
+export type EvidenceVisionCustodyScope =
+  | 'tenant-only'
+  | 'project-joint-custody'
+  | 'public-reference';
+
+export type EvidenceVisionArtifactType = 'image' | 'video' | 'image-sequence';
+
+export type EvidenceVisionObservationKind =
+  | 'progress-indicator'
+  | 'defect-risk'
+  | 'safety-risk'
+  | 'quantity-estimate'
+  | 'integrity-signal'
+  | 'scene-change'
+  | 'unknown';
+
+export interface EvidenceVisionArtifact {
+  artifactId: string;
+  type: EvidenceVisionArtifactType;
+  uri: string;
+  sha256?: string;
+  capturedAt?: Date;
+  capturedByUserId?: string;
+  location?: EvidenceVisionLocation;
+  declaredWorkItemId?: string;
+}
+
+export interface EvidenceVisionLocation {
+  latitude: number;
+  longitude: number;
+  accuracyMeters?: number;
+}
+
+export interface EvidenceVisionRequestMetadata {
+  requestId: string;
+  organisationId: string;
+  projectId: string;
+  actorUserId: string;
+  purpose: EvidenceVisionPurpose;
+  custodyScope: EvidenceVisionCustodyScope;
+  policyTags: readonly string[];
+  retention: 'audit-log' | 'case-record';
+  requestedAt: Date;
+  traceId?: string;
+}
+
+export interface EvidenceVisionRequest {
+  provider: EvidenceVisionProvider;
+  model: string;
+  artifacts: readonly EvidenceVisionArtifact[];
+  metadata: EvidenceVisionRequestMetadata;
+  comparisonArtifactIds?: readonly string[];
+  instructions?: string;
+}
+
+export interface EvidenceVisionObservation {
+  observationId: string;
+  artifactId: string;
+  kind: EvidenceVisionObservationKind;
+  label: string;
+  summary: string;
+  confidence: number;
+  severity?: 'info' | 'low' | 'medium' | 'high' | 'critical';
+  boundingBox?: EvidenceVisionBoundingBox;
+  measuredValue?: EvidenceVisionMeasuredValue;
+  reviewRequired: boolean;
+  recommendedAction?: string;
+}
+
+export interface EvidenceVisionBoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface EvidenceVisionMeasuredValue {
+  value: number;
+  unit: string;
+  qualifier: 'estimated' | 'detected' | 'declared';
+}
+
+export interface EvidenceVisionResponse {
+  requestId: string;
+  provider: EvidenceVisionProvider;
+  model: string;
+  observations: readonly EvidenceVisionObservation[];
+  provenance: EvidenceVisionProvenance;
+  completedAt: Date;
+}
+
+export interface EvidenceVisionProvenance {
+  sourceArtifactIds: readonly string[];
+  modelVersion?: string;
+  providerResponseId?: string;
+  promptHash?: string;
+}
+
+export interface EvidenceVisionAuditEvent {
+  requestId: string;
+  organisationId: string;
+  projectId: string;
+  actorUserId: string;
+  provider: EvidenceVisionProvider;
+  model: string;
+  purpose: EvidenceVisionPurpose;
+  custodyScope: EvidenceVisionCustodyScope;
+  policyTags: readonly string[];
+  retention: EvidenceVisionRequestMetadata['retention'];
+  artifactIds: readonly string[];
+  traceId?: string;
+  requestedAt: Date;
+  completedAt?: Date;
+  outcome: 'accepted' | 'rejected' | 'completed' | 'failed';
+  reason?: string;
+  observationCount?: number;
+  reviewRequired?: boolean;
+}
+
+export interface EvidenceVisionProviderClient {
+  analyze(request: EvidenceVisionRequest): Promise<EvidenceVisionResponse>;
+}
+
+export interface EvidenceVisionAuditSink {
+  record(event: EvidenceVisionAuditEvent): Promise<void>;
+}
+
+export interface EvidenceVisionPolicy {
+  evaluate(request: EvidenceVisionRequest): Promise<EvidenceVisionPolicyDecision>;
+}
+
+export interface EvidenceVisionPolicyDecision {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface EvidenceVision {
+  analyze(request: EvidenceVisionRequest): Promise<EvidenceVisionResponse>;
+}
+
+export interface CreateEvidenceVisionOptions {
+  providers: Readonly<Record<EvidenceVisionProvider, EvidenceVisionProviderClient | undefined>>;
+  auditSink: EvidenceVisionAuditSink;
+  policy?: EvidenceVisionPolicy;
+  now?: () => Date;
+}
+
+const allowAllPolicy: EvidenceVisionPolicy = {
+  async evaluate(): Promise<EvidenceVisionPolicyDecision> {
+    return { allowed: true };
+  },
+};
+
+export function createEvidenceVision(options: CreateEvidenceVisionOptions): EvidenceVision {
+  const policy = options.policy ?? allowAllPolicy;
+  const now = options.now ?? (() => new Date());
+
+  return {
+    async analyze(request) {
+      assertAuditableVisionRequest(request);
+
+      const provider = options.providers[request.provider];
+      if (provider === undefined) {
+        const reason = `vision provider ${request.provider} is not configured`;
+        await options.auditSink.record(toAuditEvent(request, 'rejected', { reason }));
+        throw new Error(reason);
+      }
+
+      const decision = await policy.evaluate(request);
+      if (!decision.allowed) {
+        const reason = decision.reason ?? 'request rejected by evidence vision policy';
+        await options.auditSink.record(toAuditEvent(request, 'rejected', { reason }));
+        throw new Error(reason);
+      }
+
+      await options.auditSink.record(toAuditEvent(request, 'accepted'));
+
+      try {
+        const response = await provider.analyze(request);
+        const completedAt = response.completedAt ?? now();
+        const observations = response.observations.map(normalizeObservation);
+        const completedAudit: Pick<
+          EvidenceVisionAuditEvent,
+          'completedAt' | 'observationCount' | 'reviewRequired'
+        > = {
+          completedAt,
+          observationCount: observations.length,
+          reviewRequired: observations.some((observation) => observation.reviewRequired),
+        };
+
+        await options.auditSink.record(toAuditEvent(request, 'completed', completedAudit));
+
+        return {
+          ...response,
+          requestId: request.metadata.requestId,
+          provider: request.provider,
+          model: request.model,
+          observations,
+          provenance: {
+            ...response.provenance,
+            sourceArtifactIds: request.artifacts.map((artifact) => artifact.artifactId),
+          },
+          completedAt,
+        };
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : 'vision provider request failed';
+        await options.auditSink.record(toAuditEvent(request, 'failed', { reason }));
+        throw error;
+      }
+    },
+  };
+}
+
+export function assertAuditableVisionRequest(request: EvidenceVisionRequest): void {
+  assertPresent(request.metadata.requestId, 'metadata.requestId');
+  assertPresent(request.metadata.organisationId, 'metadata.organisationId');
+  assertPresent(request.metadata.projectId, 'metadata.projectId');
+  assertPresent(request.metadata.actorUserId, 'metadata.actorUserId');
+  assertPresent(request.metadata.purpose, 'metadata.purpose');
+  assertPresent(request.metadata.custodyScope, 'metadata.custodyScope');
+  assertPresent(request.metadata.retention, 'metadata.retention');
+  assertPresent(request.provider, 'provider');
+  assertPresent(request.model, 'model');
+
+  if (request.artifacts.length === 0) {
+    throw new Error('artifacts must contain at least one artifact');
+  }
+
+  if (request.metadata.policyTags.length === 0) {
+    throw new Error('metadata.policyTags must contain at least one policy tag');
+  }
+
+  for (const artifact of request.artifacts) {
+    assertPresent(artifact.artifactId, 'artifact.artifactId');
+    assertPresent(artifact.type, 'artifact.type');
+    assertPresent(artifact.uri, 'artifact.uri');
+  }
+}
+
+export function requiresHumanReview(observations: readonly EvidenceVisionObservation[]): boolean {
+  return observations.some(
+    (observation) => observation.reviewRequired || observation.confidence < 0.85,
+  );
+}
+
+function normalizeObservation(observation: EvidenceVisionObservation): EvidenceVisionObservation {
+  if (observation.confidence < 0 || observation.confidence > 1) {
+    throw new Error('observation confidence must be between 0 and 1');
+  }
+
+  return {
+    ...observation,
+    reviewRequired: observation.reviewRequired || observation.confidence < 0.85,
+  };
+}
+
+function assertPresent(value: string, field: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${field} is required`);
+  }
+}
+
+function toAuditEvent(
+  request: EvidenceVisionRequest,
+  outcome: EvidenceVisionAuditEvent['outcome'],
+  extras: Pick<
+    EvidenceVisionAuditEvent,
+    'completedAt' | 'observationCount' | 'reason' | 'reviewRequired'
+  > = {},
+): EvidenceVisionAuditEvent {
+  const event: EvidenceVisionAuditEvent = {
+    requestId: request.metadata.requestId,
+    organisationId: request.metadata.organisationId,
+    projectId: request.metadata.projectId,
+    actorUserId: request.metadata.actorUserId,
+    provider: request.provider,
+    model: request.model,
+    purpose: request.metadata.purpose,
+    custodyScope: request.metadata.custodyScope,
+    policyTags: request.metadata.policyTags,
+    retention: request.metadata.retention,
+    artifactIds: request.artifacts.map((artifact) => artifact.artifactId),
+    requestedAt: request.metadata.requestedAt,
+    outcome,
+  };
+
+  if (request.metadata.traceId !== undefined) {
+    event.traceId = request.metadata.traceId;
+  }
+
+  if (extras.completedAt !== undefined) {
+    event.completedAt = extras.completedAt;
+  }
+
+  if (extras.observationCount !== undefined) {
+    event.observationCount = extras.observationCount;
+  }
+
+  if (extras.reason !== undefined) {
+    event.reason = extras.reason;
+  }
+
+  if (extras.reviewRequired !== undefined) {
+    event.reviewRequired = extras.reviewRequired;
+  }
+
+  return event;
+}

--- a/packages/evidence-vision/tsconfig.json
+++ b/packages/evidence-vision/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add @batios/evidence-vision as a provider-neutral computer vision boundary
- define auditable request, artifact, observation, provenance, policy, provider, and audit sink contracts
- enforce tenant/project/actor/custody/policy metadata before provider calls
- add docs that frame CV as human-reviewable observations, not final payment/compliance authority

## Verification
- corepack pnpm --filter @batios/evidence-vision build
- corepack pnpm --filter @batios/evidence-vision typecheck
- corepack pnpm --filter @batios/evidence-vision test
- corepack pnpm --filter @batios/evidence-vision lint
- corepack pnpm build
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan

Closes #38