### PR TITLE
Wire evidence vision observations into artifact events

### DIFF
--- a/docs/EVIDENCE_VISION.md
+++ b/docs/EVIDENCE_VISION.md
@@ -48,3 +48,11 @@ The first production adapter should be added behind the package interfaces and
 routed through policy and audit sinks. Provider responses should be retained as
 case records only when the request metadata allows it, and artifacts must not be
 used for model training unless a future tenant policy explicitly permits it.
+
+## Event Log Path
+
+Vision responses can be persisted through `@batios/events-core` as
+`artifact.vision.observed` events. The event payload includes provider/model
+provenance, source artifact IDs, observation count, review requirement, and the
+human-readable observations. These events are append-only and additive: they do
+not mutate the source artifact or replace human certification.

--- a/packages/events-core/package.json
+++ b/packages/events-core/package.json
@@ -15,6 +15,7 @@
     "clean": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
+    "@batios/evidence-vision": "workspace:*",
     "kysely": "^0.27.5"
   }
 }

--- a/packages/events-core/src/artifact-events.test.ts
+++ b/packages/events-core/src/artifact-events.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { toArtifactEventInsert, type ArtifactEventInput } from './artifact-events.js';
+import {
+  toArtifactEventInsert,
+  toVisionObservationArtifactEventInput,
+  type ArtifactEventInput,
+} from './artifact-events.js';
 
 const baseInput: ArtifactEventInput = {
   artifactId: '11111111-1111-4111-8111-111111111111',
@@ -53,5 +57,108 @@ describe('artifact event append input', () => {
     expect(insert.causation_id).toBeNull();
     expect(insert.correlation_id).toBeNull();
     expect(insert).not.toHaveProperty('event_id');
+  });
+
+  it('maps evidence vision observations to append-only artifact events', () => {
+    const completedAt = new Date('2026-04-29T12:00:00.000Z');
+    const input = toVisionObservationArtifactEventInput({
+      response: {
+        requestId: 'vision_req_01',
+        provider: 'local',
+        model: 'batios-vision-local',
+        completedAt,
+        provenance: {
+          sourceArtifactIds: ['11111111-1111-4111-8111-111111111111'],
+          modelVersion: 'local-test',
+          providerResponseId: 'provider_01',
+          promptHash: 'prompt_hash_01',
+        },
+        observations: [
+          {
+            observationId: 'obs_01',
+            artifactId: '11111111-1111-4111-8111-111111111111',
+            kind: 'progress-indicator',
+            label: 'Drainage trench visible',
+            summary: 'The uploaded image shows an excavated drainage trench.',
+            confidence: 0.91,
+            severity: 'info',
+            reviewRequired: true,
+            recommendedAction: 'Confirm dimensions before payment certification.',
+          },
+        ],
+      },
+      artifactId: '11111111-1111-4111-8111-111111111111',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      causationId: '88888888-8888-4888-8888-888888888888',
+      correlationId: '99999999-9999-4999-8999-999999999999',
+    });
+
+    expect(input).toMatchObject({
+      artifactId: '11111111-1111-4111-8111-111111111111',
+      projectId: '22222222-2222-4222-8222-222222222222',
+      organisationId: '33333333-3333-4333-8333-333333333333',
+      eventType: 'artifact.vision.observed',
+      occurredAt: completedAt,
+      actorUserId: '44444444-4444-4444-8444-444444444444',
+      idempotencyKey:
+        'artifact:11111111-1111-4111-8111-111111111111:vision:vision_req_01:batios-vision-local',
+      causationId: '88888888-8888-4888-8888-888888888888',
+      correlationId: '99999999-9999-4999-8999-999999999999',
+    });
+    expect(input.payload).toMatchObject({
+      requestId: 'vision_req_01',
+      provider: 'local',
+      model: 'batios-vision-local',
+      completedAt: '2026-04-29T12:00:00.000Z',
+      artifactId: '11111111-1111-4111-8111-111111111111',
+      sourceArtifactIds: ['11111111-1111-4111-8111-111111111111'],
+      modelVersion: 'local-test',
+      providerResponseId: 'provider_01',
+      promptHash: 'prompt_hash_01',
+      observationCount: 1,
+      reviewRequired: true,
+      observations: [
+        {
+          observationId: 'obs_01',
+          kind: 'progress-indicator',
+          label: 'Drainage trench visible',
+          confidence: 0.91,
+          reviewRequired: true,
+        },
+      ],
+    });
+  });
+
+  it('rejects vision event mapping when no observation matches the artifact', () => {
+    expect(() =>
+      toVisionObservationArtifactEventInput({
+        response: {
+          requestId: 'vision_req_02',
+          provider: 'local',
+          model: 'batios-vision-local',
+          completedAt: new Date('2026-04-29T12:00:00.000Z'),
+          provenance: {
+            sourceArtifactIds: ['different-artifact'],
+          },
+          observations: [
+            {
+              observationId: 'obs_02',
+              artifactId: 'different-artifact',
+              kind: 'unknown',
+              label: 'No visible work item',
+              summary: 'The uploaded image did not match the requested artifact.',
+              confidence: 0.5,
+              reviewRequired: true,
+            },
+          ],
+        },
+        artifactId: '11111111-1111-4111-8111-111111111111',
+        projectId: '22222222-2222-4222-8222-222222222222',
+        organisationId: '33333333-3333-4333-8333-333333333333',
+        actorUserId: '44444444-4444-4444-8444-444444444444',
+      }),
+    ).toThrow('vision response contains no observations for artifact');
   });
 });

--- a/packages/events-core/src/artifact-events.ts
+++ b/packages/events-core/src/artifact-events.ts
@@ -1,4 +1,9 @@
 import { type Generated, type Insertable, type Kysely, type Selectable } from 'kysely';
+import {
+  requiresHumanReview,
+  type EvidenceVisionObservation,
+  type EvidenceVisionResponse,
+} from '@batios/evidence-vision';
 
 export type JsonValue =
   | string
@@ -14,10 +19,23 @@ export type ArtifactEventType =
   | 'artifact.created'
   | 'artifact.updated'
   | 'artifact.attached'
+  | 'artifact.vision.observed'
   | 'artifact.reviewed'
   | 'artifact.approved'
   | 'artifact.rejected'
   | 'artifact.superseded';
+
+export interface VisionObservationArtifactEventOptions {
+  response: EvidenceVisionResponse;
+  artifactId: string;
+  projectId: string;
+  organisationId: string;
+  actorUserId: string;
+  idempotencyKey?: string;
+  occurredAt?: Date;
+  causationId?: string | null;
+  correlationId?: string | null;
+}
 
 export interface ArtifactEventsTable {
   event_id: Generated<string>;
@@ -76,6 +94,83 @@ export function toArtifactEventInsert(input: ArtifactEventInput): ArtifactEventI
   }
 
   return insert;
+}
+
+export function toVisionObservationArtifactEventInput(
+  options: VisionObservationArtifactEventOptions,
+): ArtifactEventInput {
+  const observations = options.response.observations.filter(
+    (observation) => observation.artifactId === options.artifactId,
+  );
+
+  if (observations.length === 0) {
+    throw new Error(`vision response contains no observations for artifact ${options.artifactId}`);
+  }
+
+  return {
+    artifactId: options.artifactId,
+    projectId: options.projectId,
+    organisationId: options.organisationId,
+    eventType: 'artifact.vision.observed',
+    occurredAt: options.occurredAt ?? options.response.completedAt,
+    actorUserId: options.actorUserId,
+    idempotencyKey:
+      options.idempotencyKey ??
+      `artifact:${options.artifactId}:vision:${options.response.requestId}:${options.response.model}`,
+    payload: toVisionObservationPayload(options.response, options.artifactId, observations),
+    causationId: options.causationId ?? null,
+    correlationId: options.correlationId ?? null,
+  };
+}
+
+function toVisionObservationPayload(
+  response: EvidenceVisionResponse,
+  artifactId: string,
+  observations: readonly EvidenceVisionObservation[],
+): ArtifactEventPayload {
+  return {
+    requestId: response.requestId,
+    provider: response.provider,
+    model: response.model,
+    completedAt: response.completedAt.toISOString(),
+    artifactId,
+    sourceArtifactIds: response.provenance.sourceArtifactIds,
+    modelVersion: response.provenance.modelVersion ?? null,
+    providerResponseId: response.provenance.providerResponseId ?? null,
+    promptHash: response.provenance.promptHash ?? null,
+    observationCount: observations.length,
+    reviewRequired: requiresHumanReview(observations),
+    observations: observations.map(
+      (observation): ArtifactEventPayload => ({
+        observationId: observation.observationId,
+        artifactId: observation.artifactId,
+        kind: observation.kind,
+        label: observation.label,
+        summary: observation.summary,
+        confidence: observation.confidence,
+        severity: observation.severity ?? null,
+        boundingBox:
+          observation.boundingBox === undefined
+            ? null
+            : {
+                x: observation.boundingBox.x,
+                y: observation.boundingBox.y,
+                width: observation.boundingBox.width,
+                height: observation.boundingBox.height,
+              },
+        measuredValue:
+          observation.measuredValue === undefined
+            ? null
+            : {
+                value: observation.measuredValue.value,
+                unit: observation.measuredValue.unit,
+                qualifier: observation.measuredValue.qualifier,
+              },
+        reviewRequired: observation.reviewRequired,
+        recommendedAction: observation.recommendedAction ?? null,
+      }),
+    ),
+  };
 }
 
 export async function appendArtifactEvent(

--- a/packages/events-core/src/migrations/0001-artifact-events.ts
+++ b/packages/events-core/src/migrations/0001-artifact-events.ts
@@ -40,6 +40,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
           'artifact.created',
           'artifact.updated',
           'artifact.attached',
+          'artifact.vision.observed',
           'artifact.reviewed',
           'artifact.approved',
           'artifact.rejected',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,14 @@ importers:
 
   packages/events-core:
     dependencies:
+      '@batios/evidence-vision':
+        specifier: workspace:*
+        version: link:../evidence-vision
       kysely:
         specifier: ^0.27.5
         version: 0.27.6
+
+  packages/evidence-vision: {}
 
   packages/ipc-autopilot:
     dependencies:


### PR DESCRIPTION
## Summary
- add artifact.vision.observed events for evidence vision responses
- map provider/model provenance, review requirement, and observations into append-only artifact payloads
- document the event log path and update the event migration constraint

## Checks
- corepack pnpm build
- corepack pnpm lint
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm format:check
- corepack pnpm qa:harness
- corepack pnpm compliance:scan
- corepack pnpm e2e:workflow

Closes #40